### PR TITLE
feat : [003 - Transaction API]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ configurations {
 
 repositories {
     mavenCentral()
+    maven { url 'https://jitpack.io' }
 }
 
 dependencies {
@@ -31,6 +32,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation group: 'com.auth0', name: 'java-jwt', version: '4.4.0'
+    implementation 'com.github.iamport:iamport-rest-client-java:0.2.23'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/coffee/coffeeserviceproject/bean/entity/Bean.java
+++ b/src/main/java/com/coffee/coffeeserviceproject/bean/entity/Bean.java
@@ -78,4 +78,11 @@ public class Bean {
     }
     return null;
   }
+
+  public Long getRoasterId() {
+    if (member != null && member.getRoaster() != null) {
+      return member.getRoaster().getId();
+    }
+    return null;
+  }
 }

--- a/src/main/java/com/coffee/coffeeserviceproject/common/exception/CustomException.java
+++ b/src/main/java/com/coffee/coffeeserviceproject/common/exception/CustomException.java
@@ -1,12 +1,23 @@
 package com.coffee.coffeeserviceproject.common.exception;
 
 import com.coffee.coffeeserviceproject.common.type.ErrorCode;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 public class CustomException extends RuntimeException{
 
   private final ErrorCode errorCode;
+  private final String addMessage;
+
+  public CustomException(ErrorCode errorCode) {
+    super(errorCode.getMessage());
+    this.errorCode = errorCode;
+    this.addMessage = errorCode.getMessage();
+  }
+
+  public CustomException(ErrorCode errorCode, String addMessage) {
+    super(errorCode.getMessage() + (addMessage != null ? "-> " + addMessage : ""));
+    this.errorCode = errorCode;
+    this.addMessage = addMessage;
+  }
 }

--- a/src/main/java/com/coffee/coffeeserviceproject/common/type/ErrorCode.java
+++ b/src/main/java/com/coffee/coffeeserviceproject/common/type/ErrorCode.java
@@ -20,7 +20,18 @@ public enum ErrorCode {
   PRICE_REQUIRED("PRICE_REQUIRED", "판매상태가 등록된 경우 가격은 필수 입력입니다."),
   NOT_FOUND_BEAN("NOT_FOUND_BEAN", "원두정보를 찾을수 없습니다."),
   NOT_PERMISSION("NOT_PERMISSION", "승인되지 않은 요청입니다."),
-  ROASTER_REGISTRATION_FAILED("ROASTER_REGISTRATION_FAILED", "로스터 등록에 실패하였습니다. 고객센터에 문의해 주세요")
+  ROASTER_REGISTRATION_FAILED("ROASTER_REGISTRATION_FAILED", "로스터 등록에 실패하였습니다. 고객센터에 문의해 주세요"),
+  NOT_AVAILABLE_PURCHASE("NOT_AVAILABLE_PURCHASE", "구매가 불가능한 상품입니다."),
+  MAX_QUANTITY("MAX_QUANTITY", "최대수량은 100개 까지 입니다"),
+  NOT_FOUND_CART("NOT_FOUND_CART", "장바구니 정보가 없습니다."),
+  PAYMENT_ERROR("PAYMENT_ERROR", "결제 처리 중 오류가 발생하였습니다."),
+  PRICE_CHANGE("PRICE_CHANGE", "상품 가격이 변경되었습니다."),
+  NOT_FOUND_ORDER("NOT_FOUND_ORDER", "해당 주문을 찾을 수 없습니다."),
+  INVALID_AMOUNT("INVALID_AMOUNT", "주문 금액이 일치하지 않습니다."),
+  INVALID_STATUS("INVALID_STATUS", "잘못된 요청입니다."),
+  FAILURE_CANCEL("FAILURE_CANCEL", "결제 취소에 실패하였습니다."),
+  SAME_ROASTER("SAME_ROASTER", "동일한 로스터의 원두만 주문이 가능합니다."),
+  NOT_FOUND_ROASTER("NOT_FOUND_ROASTER", "로스터를 찾지 못했습니다.")
   ;
 
   private final String code;

--- a/src/main/java/com/coffee/coffeeserviceproject/configuration/PortOneConfig.java
+++ b/src/main/java/com/coffee/coffeeserviceproject/configuration/PortOneConfig.java
@@ -1,0 +1,21 @@
+package com.coffee.coffeeserviceproject.configuration;
+
+import com.siot.IamportRestClient.IamportClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class PortOneConfig {
+
+  @Value("${imp.v1.api.key}")
+  private String apiKey;
+
+  @Value("${imp.v1.api.secret}")
+  private String apiSecretKey;
+
+  @Bean
+  public IamportClient iamportClient() {
+    return new IamportClient(apiKey, apiSecretKey);
+  }
+}

--- a/src/main/java/com/coffee/coffeeserviceproject/order/cart/controller/CartController.java
+++ b/src/main/java/com/coffee/coffeeserviceproject/order/cart/controller/CartController.java
@@ -1,0 +1,64 @@
+package com.coffee.coffeeserviceproject.order.cart.controller;
+
+import com.coffee.coffeeserviceproject.order.cart.dto.CartDto;
+import com.coffee.coffeeserviceproject.order.cart.dto.CartListDto;
+import com.coffee.coffeeserviceproject.order.cart.dto.CartUpdateDto;
+import com.coffee.coffeeserviceproject.order.cart.service.CartService;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/carts")
+public class CartController {
+
+  private final CartService cartService;
+
+  @PostMapping("/{beanId}")
+  public ResponseEntity<Void> addCart(@PathVariable("beanId") Long beanId,
+      @RequestBody @Valid CartDto cartDto,
+      @RequestHeader("AUTH-TOKEN") String token) {
+
+    cartService.addCart(beanId, cartDto, token);
+
+    return ResponseEntity.noContent().build();
+  }
+
+  @GetMapping
+  public ResponseEntity<List<CartListDto>> getCart(@RequestHeader("AUTH-TOKEN") String token) {
+
+    List<CartListDto> cartListDto = cartService.getCart(token);
+
+    return ResponseEntity.ok(cartListDto);
+  }
+
+  @PatchMapping("/{id}")
+  public ResponseEntity<Void> updateCart(@PathVariable("id") Long id,
+      @RequestBody @Valid CartUpdateDto cartUpdateDto,
+      @RequestHeader("AUTH-TOKEN") String token) {
+
+    cartService.updateCart(id, cartUpdateDto, token);
+
+    return ResponseEntity.noContent().build();
+  }
+
+  @DeleteMapping("/{id}")
+  public ResponseEntity<Void> deleteCart(@PathVariable("id") Long id,
+      @RequestHeader("AUTH-TOKEN") String token) {
+
+    cartService.deleteCart(id, token);
+
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/src/main/java/com/coffee/coffeeserviceproject/order/cart/dto/CartDto.java
+++ b/src/main/java/com/coffee/coffeeserviceproject/order/cart/dto/CartDto.java
@@ -1,0 +1,17 @@
+package com.coffee.coffeeserviceproject.order.cart.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Positive;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class CartDto {
+
+  @Positive(message = "최소 1개 이상 장바구니에 담을 수 있습니다.")
+  @Max(value = 100, message = "최대 수량은 100개 까지 입니다.")
+  private int quantity;
+
+  private String requestNote;
+}

--- a/src/main/java/com/coffee/coffeeserviceproject/order/cart/dto/CartListDto.java
+++ b/src/main/java/com/coffee/coffeeserviceproject/order/cart/dto/CartListDto.java
@@ -1,0 +1,31 @@
+package com.coffee.coffeeserviceproject.order.cart.dto;
+
+import com.coffee.coffeeserviceproject.order.cart.entity.Cart;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class CartListDto {
+
+  private String roasterName;
+
+  private String beanName;
+
+  private int quantity;
+
+  private Long priceAtAdded;
+
+  private String requestNote;
+
+  public static CartListDto fromEntity(Cart cart) {
+
+    return CartListDto.builder()
+            .roasterName(cart.getBean().getRoasterName())
+            .beanName(cart.getBean().getBeanName())
+            .quantity(cart.getQuantity())
+            .priceAtAdded(cart.getPriceAtAdded())
+            .requestNote(cart.getRequestNote())
+            .build();
+  }
+}

--- a/src/main/java/com/coffee/coffeeserviceproject/order/cart/dto/CartUpdateDto.java
+++ b/src/main/java/com/coffee/coffeeserviceproject/order/cart/dto/CartUpdateDto.java
@@ -1,0 +1,15 @@
+package com.coffee.coffeeserviceproject.order.cart.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Positive;
+import lombok.Data;
+
+@Data
+public class CartUpdateDto {
+
+  @Positive(message = "최소 1개 이상 장바구니에 담을 수 있습니다.")
+  @Max(value = 100, message = "최대 수량은 100개 까지 입니다.")
+  private Integer quantity;
+
+  private String requestNote;
+}

--- a/src/main/java/com/coffee/coffeeserviceproject/order/cart/entity/Cart.java
+++ b/src/main/java/com/coffee/coffeeserviceproject/order/cart/entity/Cart.java
@@ -1,0 +1,52 @@
+package com.coffee.coffeeserviceproject.order.cart.entity;
+
+import com.coffee.coffeeserviceproject.bean.entity.Bean;
+import com.coffee.coffeeserviceproject.member.entity.Member;
+import com.coffee.coffeeserviceproject.order.cart.dto.CartDto;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Cart {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long cartId;
+
+  @ManyToOne
+  @JoinColumn(name = "member_id", nullable = false)
+  private Member member;
+
+  @ManyToOne
+  @JoinColumn(name = "bean_id", nullable = false)
+  private Bean bean;
+
+  private int quantity;
+
+  private Long priceAtAdded;
+
+  private String requestNote;
+
+  public static Cart fromDto(CartDto cartDto, Member member, Bean bean) {
+
+    return Cart.builder()
+        .member(member)
+        .bean(bean)
+        .quantity(cartDto.getQuantity())
+        .priceAtAdded(bean.getPrice())
+        .requestNote(cartDto.getRequestNote())
+        .build();
+  }
+}

--- a/src/main/java/com/coffee/coffeeserviceproject/order/cart/repository/CartRepository.java
+++ b/src/main/java/com/coffee/coffeeserviceproject/order/cart/repository/CartRepository.java
@@ -1,0 +1,16 @@
+package com.coffee.coffeeserviceproject.order.cart.repository;
+
+import com.coffee.coffeeserviceproject.bean.entity.Bean;
+import com.coffee.coffeeserviceproject.member.entity.Member;
+import com.coffee.coffeeserviceproject.order.cart.entity.Cart;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CartRepository extends JpaRepository<Cart, Long> {
+
+  Cart findByMemberAndBean(Member member, Bean bean);
+
+  List<Cart> findAllByMemberId(Long id);
+
+  void deleteByBeanIdAndMemberId(Long beanId, Long memberId);
+}

--- a/src/main/java/com/coffee/coffeeserviceproject/order/cart/service/CartService.java
+++ b/src/main/java/com/coffee/coffeeserviceproject/order/cart/service/CartService.java
@@ -1,0 +1,111 @@
+package com.coffee.coffeeserviceproject.order.cart.service;
+
+import static com.coffee.coffeeserviceproject.bean.type.PurchaseStatus.IMPOSSIBLE;
+import static com.coffee.coffeeserviceproject.common.type.ErrorCode.MAX_QUANTITY;
+import static com.coffee.coffeeserviceproject.common.type.ErrorCode.NOT_AVAILABLE_PURCHASE;
+import static com.coffee.coffeeserviceproject.common.type.ErrorCode.NOT_FOUND_BEAN;
+import static com.coffee.coffeeserviceproject.common.type.ErrorCode.NOT_FOUND_CART;
+import static com.coffee.coffeeserviceproject.common.type.ErrorCode.NOT_PERMISSION;
+
+import com.coffee.coffeeserviceproject.bean.entity.Bean;
+import com.coffee.coffeeserviceproject.bean.repository.BeanRepository;
+import com.coffee.coffeeserviceproject.common.exception.CustomException;
+import com.coffee.coffeeserviceproject.configuration.JwtProvider;
+import com.coffee.coffeeserviceproject.member.entity.Member;
+import com.coffee.coffeeserviceproject.order.cart.dto.CartDto;
+import com.coffee.coffeeserviceproject.order.cart.dto.CartListDto;
+import com.coffee.coffeeserviceproject.order.cart.dto.CartUpdateDto;
+import com.coffee.coffeeserviceproject.order.cart.entity.Cart;
+import com.coffee.coffeeserviceproject.order.cart.repository.CartRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CartService {
+
+  private final CartRepository cartRepository;
+
+  private final JwtProvider jwtProvider;
+
+  private final BeanRepository beanRepository;
+
+  public void addCart(Long beanId, CartDto cartDto, String token) {
+
+    Member member = jwtProvider.getMemberFromEmail(token);
+
+    Bean bean = beanRepository.findById(beanId)
+        .orElseThrow(() -> new CustomException(NOT_FOUND_BEAN));
+
+    if (bean.getPurchaseStatus() == IMPOSSIBLE || bean.getPurchaseStatus() == null) {
+      throw new CustomException(NOT_AVAILABLE_PURCHASE);
+    }
+
+    Cart existingCart = cartRepository.findByMemberAndBean(member, bean);
+
+    int totalQuantity =
+        (existingCart != null ? existingCart.getQuantity() : 0) + cartDto.getQuantity();
+
+    if (totalQuantity > 100) {
+      throw new CustomException(MAX_QUANTITY);
+    }
+
+    if (existingCart != null) {
+
+      existingCart.setQuantity(existingCart.getQuantity() + cartDto.getQuantity());
+
+      cartRepository.save(existingCart);
+
+    } else {
+
+      Cart cart = Cart.fromDto(cartDto, member, bean);
+
+      cartRepository.save(cart);
+    }
+  }
+
+  public List<CartListDto> getCart(String token) {
+
+    Member member = jwtProvider.getMemberFromEmail(token);
+
+    List<Cart> cartList = cartRepository.findAllByMemberId(member.getId());
+
+    return cartList.stream()
+        .map(CartListDto::fromEntity)
+        .toList();
+  }
+
+  public void updateCart(Long id, CartUpdateDto cartUpdateDto, String token) {
+
+    Member member = jwtProvider.getMemberFromEmail(token);
+
+    Cart cart = cartRepository.findById(id).orElseThrow(() -> new CustomException(NOT_FOUND_CART));
+
+    if (!member.equals(cart.getMember())) {
+      throw new CustomException(NOT_PERMISSION);
+    }
+
+    if (cartUpdateDto.getQuantity() != null) {
+      cart.setQuantity(cartUpdateDto.getQuantity());
+    }
+
+    if (cartUpdateDto.getRequestNote() != null) {
+      cart.setRequestNote(cartUpdateDto.getRequestNote());
+    }
+    cartRepository.save(cart);
+  }
+
+  public void deleteCart(Long id, String token) {
+
+    Member member = jwtProvider.getMemberFromEmail(token);
+
+    Cart cart = cartRepository.findById(id).orElseThrow(() -> new CustomException(NOT_FOUND_CART));
+
+    if (!member.equals(cart.getMember())) {
+      throw new CustomException(NOT_PERMISSION);
+    }
+
+    cartRepository.delete(cart);
+  }
+}

--- a/src/main/java/com/coffee/coffeeserviceproject/order/transaction/controller/TransactionController.java
+++ b/src/main/java/com/coffee/coffeeserviceproject/order/transaction/controller/TransactionController.java
@@ -39,16 +39,16 @@ public class TransactionController {
     return ResponseEntity.noContent().build();
   }
 
-  @PostMapping("/verification/{imp_uid}")
-  public IamportResponse<Payment> validatePayment(@PathVariable String imp_uid) {
+  @PostMapping("/verification/{impUid}")
+  public IamportResponse<Payment> validatePayment(@PathVariable String impUid) {
 
-    return transactionService.validateOrder(imp_uid);
+    return transactionService.validateOrder(impUid);
   }
 
-  @PostMapping("/cancel/{imp_uid}")
-  public IamportResponse<Payment> cancelOrder(@PathVariable String imp_uid) {
+  @PostMapping("/cancel/{impUid}")
+  public IamportResponse<Payment> cancelOrder(@PathVariable String impUid) {
 
-    return transactionService.cancelOrder(imp_uid);
+    return transactionService.cancelOrder(impUid);
   }
 
   @GetMapping("/buyer/purchase")

--- a/src/main/java/com/coffee/coffeeserviceproject/order/transaction/controller/TransactionController.java
+++ b/src/main/java/com/coffee/coffeeserviceproject/order/transaction/controller/TransactionController.java
@@ -40,7 +40,7 @@ public class TransactionController {
   }
 
   @PostMapping("/verification/{imp_uid}")
-  public IamportResponse<Payment> validateImp(@PathVariable String imp_uid) {
+  public IamportResponse<Payment> validatePayment(@PathVariable String imp_uid) {
 
     return transactionService.validateOrder(imp_uid);
   }

--- a/src/main/java/com/coffee/coffeeserviceproject/order/transaction/controller/TransactionController.java
+++ b/src/main/java/com/coffee/coffeeserviceproject/order/transaction/controller/TransactionController.java
@@ -1,0 +1,107 @@
+package com.coffee.coffeeserviceproject.order.transaction.controller;
+
+import com.coffee.coffeeserviceproject.common.model.ListResponseDto;
+import com.coffee.coffeeserviceproject.order.transaction.dto.TransactionBuyerListDto;
+import com.coffee.coffeeserviceproject.order.transaction.dto.TransactionDto;
+import com.coffee.coffeeserviceproject.order.transaction.dto.TransactionSellerListDto;
+import com.coffee.coffeeserviceproject.order.transaction.service.TransactionService;
+import com.coffee.coffeeserviceproject.order.transaction.type.PaymentStatusType;
+import com.siot.IamportRestClient.response.IamportResponse;
+import com.siot.IamportRestClient.response.Payment;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/order")
+public class TransactionController {
+
+  private final TransactionService transactionService;
+
+  @PostMapping
+  public ResponseEntity<Void> createOrder(@RequestBody TransactionDto transactionDto,
+      @RequestHeader("AUTH-TOKEN") String token) {
+
+    transactionService.createOrder(transactionDto, token);
+
+    return ResponseEntity.noContent().build();
+  }
+
+  @PostMapping("/verification/{imp_uid}")
+  public IamportResponse<Payment> validateImp(@PathVariable String imp_uid) {
+
+    return transactionService.validateOrder(imp_uid);
+  }
+
+  @PostMapping("/cancel/{imp_uid}")
+  public IamportResponse<Payment> cancelOrder(@PathVariable String imp_uid) {
+
+    return transactionService.cancelOrder(imp_uid);
+  }
+
+  @GetMapping("/buyer/purchase")
+  public ResponseEntity<ListResponseDto<List<TransactionBuyerListDto>>> getBuyerPurchaseList(
+      Pageable pageable,
+      @RequestHeader("AUTH-TOKEN") String token) {
+
+    Page<TransactionBuyerListDto> buyerListDtoPage = transactionService.getBuyerPurchaseList(
+        pageable, token);
+
+    ListResponseDto<List<TransactionBuyerListDto>> responseDto = new ListResponseDto<>(
+        buyerListDtoPage.getContent(),
+        buyerListDtoPage.getTotalElements(),
+        buyerListDtoPage.getTotalPages()
+    );
+
+    return ResponseEntity.ok(responseDto);
+  }
+
+  @PatchMapping("/buyer/purchase/{id}")
+  public ResponseEntity<Void> updateBuyerPurchaseList(@PathVariable Long id,
+      @RequestParam PaymentStatusType paymentStatus,
+      @RequestHeader("AUTH-TOKEN") String token) {
+
+    transactionService.updateBuyerPurchase(id, paymentStatus, token);
+
+    return ResponseEntity.noContent().build();
+  }
+
+  @GetMapping("/seller/purchase")
+  public ResponseEntity<ListResponseDto<List<TransactionSellerListDto>>> getSellerPurchaseList(
+      Pageable pageable,
+      @RequestHeader("AUTH-TOKEN") String token) {
+
+    Page<TransactionSellerListDto> sellerListDtoPage = transactionService.getSellerPurchaseList(
+        pageable, token);
+
+    ListResponseDto<List<TransactionSellerListDto>> responseDto = new ListResponseDto<>(
+        sellerListDtoPage.getContent(),
+        sellerListDtoPage.getTotalElements(),
+        sellerListDtoPage.getTotalPages()
+    );
+
+    return ResponseEntity.ok(responseDto);
+  }
+
+  @PatchMapping("/seller/purchase/{id}")
+  public ResponseEntity<Void> updateSellerPurchaseList(@PathVariable Long id,
+      @RequestParam PaymentStatusType paymentStatus,
+      @RequestHeader("AUTH-TOKEN") String token) {
+
+    transactionService.updateSellerPurchase(id, paymentStatus, token);
+
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/src/main/java/com/coffee/coffeeserviceproject/order/transaction/dto/TransactionBuyerListDto.java
+++ b/src/main/java/com/coffee/coffeeserviceproject/order/transaction/dto/TransactionBuyerListDto.java
@@ -1,0 +1,42 @@
+package com.coffee.coffeeserviceproject.order.transaction.dto;
+
+import com.coffee.coffeeserviceproject.order.transaction.entity.Item;
+import com.coffee.coffeeserviceproject.order.transaction.entity.Transaction;
+import com.coffee.coffeeserviceproject.order.transaction.type.PaymentMethodType;
+import com.coffee.coffeeserviceproject.order.transaction.type.PaymentStatusType;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class TransactionBuyerListDto {
+
+  private Long transactionId;
+
+  private List<Item> items;
+
+  private Long totalPrice;
+
+  private PaymentStatusType paymentStatus;
+
+  private PaymentMethodType paymentMethod;
+
+  private LocalDateTime createdAt;
+
+  private LocalDateTime updatedAt;
+
+  public static TransactionBuyerListDto fromEntity(Transaction transaction, List<Item> items) {
+
+    return TransactionBuyerListDto.builder()
+        .transactionId(transaction.getTransactionId())
+        .items(items)
+        .totalPrice(transaction.getTotalPrice())
+        .paymentStatus(transaction.getPaymentStatus())
+        .paymentMethod(transaction.getPaymentMethod())
+        .createdAt(transaction.getCreatedAt())
+        .updatedAt(transaction.getUpdatedAt())
+        .build();
+  }
+}

--- a/src/main/java/com/coffee/coffeeserviceproject/order/transaction/dto/TransactionDto.java
+++ b/src/main/java/com/coffee/coffeeserviceproject/order/transaction/dto/TransactionDto.java
@@ -16,5 +16,5 @@ public class TransactionDto {
 
   private PaymentMethodType paymentMethod;
 
-  List<Item> items;
+  private List<Item> items;
 }

--- a/src/main/java/com/coffee/coffeeserviceproject/order/transaction/dto/TransactionDto.java
+++ b/src/main/java/com/coffee/coffeeserviceproject/order/transaction/dto/TransactionDto.java
@@ -1,0 +1,20 @@
+package com.coffee.coffeeserviceproject.order.transaction.dto;
+
+import com.coffee.coffeeserviceproject.order.transaction.entity.Item;
+import com.coffee.coffeeserviceproject.order.transaction.type.PaymentMethodType;
+import java.util.List;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class TransactionDto {
+
+  private Long totalPrice;
+
+  private String merchant_uid;
+
+  private PaymentMethodType paymentMethod;
+
+  List<Item> items;
+}

--- a/src/main/java/com/coffee/coffeeserviceproject/order/transaction/dto/TransactionSellerListDto.java
+++ b/src/main/java/com/coffee/coffeeserviceproject/order/transaction/dto/TransactionSellerListDto.java
@@ -1,0 +1,48 @@
+package com.coffee.coffeeserviceproject.order.transaction.dto;
+
+import com.coffee.coffeeserviceproject.order.transaction.entity.Item;
+import com.coffee.coffeeserviceproject.order.transaction.entity.Transaction;
+import com.coffee.coffeeserviceproject.order.transaction.type.PaymentMethodType;
+import com.coffee.coffeeserviceproject.order.transaction.type.PaymentStatusType;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class TransactionSellerListDto {
+
+  private Long transactionId;
+
+  private Long buyerId;
+
+  private String buyerAddress;
+
+  private List<Item> items;
+
+  private Long totalPrice;
+
+  private PaymentStatusType paymentStatus;
+
+  private PaymentMethodType paymentMethod;
+
+  private LocalDateTime createdAt;
+
+  private LocalDateTime updatedAt;
+
+  public static TransactionSellerListDto fromEntity(Transaction transaction, List<Item> items) {
+
+    return TransactionSellerListDto.builder()
+        .transactionId(transaction.getTransactionId())
+        .buyerId(transaction.getMember().getId())
+        .buyerAddress(transaction.getMember().getAddress())
+        .items(items)
+        .totalPrice(transaction.getTotalPrice())
+        .paymentStatus(transaction.getPaymentStatus())
+        .paymentMethod(transaction.getPaymentMethod())
+        .createdAt(transaction.getCreatedAt())
+        .updatedAt(transaction.getUpdatedAt())
+        .build();
+  }
+}

--- a/src/main/java/com/coffee/coffeeserviceproject/order/transaction/entity/Item.java
+++ b/src/main/java/com/coffee/coffeeserviceproject/order/transaction/entity/Item.java
@@ -1,0 +1,21 @@
+package com.coffee.coffeeserviceproject.order.transaction.entity;
+
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Embeddable
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Item {
+
+  private Long beanId;
+
+  private int quantity;
+
+  private Long price;
+}

--- a/src/main/java/com/coffee/coffeeserviceproject/order/transaction/entity/Transaction.java
+++ b/src/main/java/com/coffee/coffeeserviceproject/order/transaction/entity/Transaction.java
@@ -1,0 +1,86 @@
+package com.coffee.coffeeserviceproject.order.transaction.entity;
+
+import static com.coffee.coffeeserviceproject.order.transaction.type.PaymentStatusType.READY;
+
+import com.coffee.coffeeserviceproject.member.entity.Member;
+import com.coffee.coffeeserviceproject.member.entity.Roaster;
+import com.coffee.coffeeserviceproject.order.transaction.dto.TransactionDto;
+import com.coffee.coffeeserviceproject.order.transaction.type.PaymentMethodType;
+import com.coffee.coffeeserviceproject.order.transaction.type.PaymentStatusType;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Transaction {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long transactionId;
+
+  @ManyToOne
+  @JoinColumn(name = "member_id", nullable = false)
+  private Member member;
+
+  @ManyToOne
+  @JoinColumn(name = "roaster_id", nullable = false)
+  private Roaster roaster;
+
+  private String merchantUid;
+
+  @ElementCollection
+  private List<Item> items;
+
+  private Long totalPrice;
+
+  @Enumerated(EnumType.STRING)
+  private PaymentStatusType paymentStatus;
+
+  @Enumerated(EnumType.STRING)
+  private PaymentMethodType paymentMethod;
+
+  private LocalDateTime createdAt;
+
+  private LocalDateTime updatedAt;
+
+  @PrePersist
+  public void onCreate() {
+    this.createdAt = LocalDateTime.now();
+  }
+
+  @PreUpdate
+  public void onUpdate() {
+    this.updatedAt = LocalDateTime.now();
+  }
+
+  public static Transaction fromDto(TransactionDto transactionDto, Member member, Roaster roaster, List<Item> items) {
+
+    return Transaction.builder()
+        .member(member)
+        .roaster(roaster)
+        .paymentStatus(READY)
+        .items(items)
+        .merchantUid(transactionDto.getMerchant_uid())
+        .paymentMethod(transactionDto.getPaymentMethod())
+        .build();
+  }
+}
+

--- a/src/main/java/com/coffee/coffeeserviceproject/order/transaction/repository/TransactionRepository.java
+++ b/src/main/java/com/coffee/coffeeserviceproject/order/transaction/repository/TransactionRepository.java
@@ -1,0 +1,16 @@
+package com.coffee.coffeeserviceproject.order.transaction.repository;
+
+import com.coffee.coffeeserviceproject.order.transaction.entity.Transaction;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TransactionRepository extends JpaRepository<Transaction, Long> {
+
+  Optional<Transaction> findByMerchantUid(String merchantUid);
+
+  Page<Transaction> findByMemberId(Long memberId, Pageable pageable);
+
+  Page<Transaction> findByRoasterId(Long roasterId, Pageable pageable);
+}

--- a/src/main/java/com/coffee/coffeeserviceproject/order/transaction/service/TransactionService.java
+++ b/src/main/java/com/coffee/coffeeserviceproject/order/transaction/service/TransactionService.java
@@ -1,0 +1,324 @@
+package com.coffee.coffeeserviceproject.order.transaction.service;
+
+import static com.coffee.coffeeserviceproject.bean.type.PurchaseStatus.IMPOSSIBLE;
+import static com.coffee.coffeeserviceproject.common.type.ErrorCode.FAILURE_CANCEL;
+import static com.coffee.coffeeserviceproject.common.type.ErrorCode.INVALID_AMOUNT;
+import static com.coffee.coffeeserviceproject.common.type.ErrorCode.INVALID_STATUS;
+import static com.coffee.coffeeserviceproject.common.type.ErrorCode.NOT_AVAILABLE_PURCHASE;
+import static com.coffee.coffeeserviceproject.common.type.ErrorCode.NOT_FOUND_BEAN;
+import static com.coffee.coffeeserviceproject.common.type.ErrorCode.NOT_FOUND_ORDER;
+import static com.coffee.coffeeserviceproject.common.type.ErrorCode.NOT_FOUND_ROASTER;
+import static com.coffee.coffeeserviceproject.common.type.ErrorCode.NOT_PERMISSION;
+import static com.coffee.coffeeserviceproject.common.type.ErrorCode.PAYMENT_ERROR;
+import static com.coffee.coffeeserviceproject.common.type.ErrorCode.PRICE_CHANGE;
+import static com.coffee.coffeeserviceproject.common.type.ErrorCode.SAME_ROASTER;
+import static com.coffee.coffeeserviceproject.member.type.RoleType.SELLER;
+import static com.coffee.coffeeserviceproject.order.transaction.type.PaymentStatusType.CANCELED;
+import static com.coffee.coffeeserviceproject.order.transaction.type.PaymentStatusType.CANCEL_REQUEST;
+import static com.coffee.coffeeserviceproject.order.transaction.type.PaymentStatusType.DELIVERED;
+import static com.coffee.coffeeserviceproject.order.transaction.type.PaymentStatusType.DELIVERY;
+import static com.coffee.coffeeserviceproject.order.transaction.type.PaymentStatusType.EXCHANGED;
+import static com.coffee.coffeeserviceproject.order.transaction.type.PaymentStatusType.EXCHANGE_REQUEST;
+import static com.coffee.coffeeserviceproject.order.transaction.type.PaymentStatusType.ORDER_CONFIRMED;
+import static com.coffee.coffeeserviceproject.order.transaction.type.PaymentStatusType.PAID;
+import static com.coffee.coffeeserviceproject.order.transaction.type.PaymentStatusType.PREPARE;
+import static com.coffee.coffeeserviceproject.order.transaction.type.PaymentStatusType.READY;
+
+import com.coffee.coffeeserviceproject.bean.entity.Bean;
+import com.coffee.coffeeserviceproject.bean.repository.BeanRepository;
+import com.coffee.coffeeserviceproject.common.exception.CustomException;
+import com.coffee.coffeeserviceproject.configuration.JwtProvider;
+import com.coffee.coffeeserviceproject.member.entity.Member;
+import com.coffee.coffeeserviceproject.member.entity.Roaster;
+import com.coffee.coffeeserviceproject.member.repository.RoasterRepository;
+import com.coffee.coffeeserviceproject.order.cart.repository.CartRepository;
+import com.coffee.coffeeserviceproject.order.transaction.dto.TransactionBuyerListDto;
+import com.coffee.coffeeserviceproject.order.transaction.dto.TransactionDto;
+import com.coffee.coffeeserviceproject.order.transaction.dto.TransactionSellerListDto;
+import com.coffee.coffeeserviceproject.order.transaction.entity.Item;
+import com.coffee.coffeeserviceproject.order.transaction.entity.Transaction;
+import com.coffee.coffeeserviceproject.order.transaction.repository.TransactionRepository;
+import com.coffee.coffeeserviceproject.order.transaction.type.PaymentStatusType;
+import com.siot.IamportRestClient.IamportClient;
+import com.siot.IamportRestClient.exception.IamportResponseException;
+import com.siot.IamportRestClient.request.CancelData;
+import com.siot.IamportRestClient.response.IamportResponse;
+import com.siot.IamportRestClient.response.Payment;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TransactionService {
+
+  private final TransactionRepository transactionRepository;
+
+  private final JwtProvider jwtProvider;
+
+  private final BeanRepository beanRepository;
+
+  private final IamportClient iamportClient;
+
+  private final CartRepository cartRepository;
+
+  private final RoasterRepository roasterRepository;
+
+  @Transactional
+  public void createOrder(TransactionDto transactionDto, String token) {
+
+    Member member = jwtProvider.getMemberFromEmail(token);
+
+    List<Item> items = new ArrayList<>();
+
+    Long firstBeanId = transactionDto.getItems().get(0).getBeanId();
+
+    Long roasterId = beanRepository.findById(firstBeanId)
+        .orElseThrow(() -> new CustomException(NOT_FOUND_BEAN)).getRoasterId();
+
+    Roaster roaster = roasterRepository.findById(roasterId)
+        .orElseThrow(() -> new CustomException(NOT_FOUND_ROASTER));
+
+    for (Item item : transactionDto.getItems()) {
+
+      Bean bean = beanRepository.findById(item.getBeanId())
+          .orElseThrow(() -> new CustomException(NOT_FOUND_BEAN));
+
+      if (bean.getPurchaseStatus() == IMPOSSIBLE) {
+        throw new CustomException(NOT_AVAILABLE_PURCHASE, bean.getBeanName());
+      }
+
+      if (!bean.getPrice().equals(item.getPrice())) {
+        throw new CustomException(PRICE_CHANGE, bean.getBeanName());
+      }
+
+      Long currentRoasterId = bean.getRoasterId();
+
+      if (!roaster.getId().equals(currentRoasterId)) {
+        throw new CustomException(SAME_ROASTER);
+      }
+
+      items.add(Item.builder()
+          .beanId(item.getBeanId())
+          .quantity(item.getQuantity())
+          .price(item.getPrice())
+          .build());
+    }
+
+    Transaction transaction = Transaction.fromDto(transactionDto, member, roaster, items);
+
+    transactionRepository.save(transaction);
+  }
+
+  @Transactional
+  public IamportResponse<Payment> validateOrder(String impUid) {
+
+    try {
+
+      IamportResponse<Payment> response = iamportClient.paymentByImpUid(impUid);
+      Payment payment = response.getResponse();
+
+      Transaction transaction = transactionRepository.findByMerchantUid(payment.getMerchantUid())
+          .orElseThrow(() -> new CustomException(NOT_FOUND_ORDER));
+
+      if (!payment.getStatus().equals("paid") || !transaction.getPaymentStatus().equals(READY)) {
+
+        throw new CustomException(INVALID_STATUS);
+      }
+
+      BigDecimal totalAmount = transaction.getItems().stream().map(
+              item -> BigDecimal.valueOf(item.getPrice())
+                  .multiply(BigDecimal.valueOf(item.getQuantity())))
+          .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+      if (payment.getAmount().compareTo(totalAmount) != 0) {
+
+        throw new CustomException(INVALID_AMOUNT);
+      }
+
+      transaction.setTotalPrice(totalAmount.longValue());
+      transaction.setPaymentStatus(PAID);
+      transactionRepository.save(transaction);
+
+      for (Item item : transaction.getItems()) {
+
+        cartRepository.deleteByBeanIdAndMemberId(item.getBeanId(),
+            transaction.getMember().getId());
+      }
+
+      return response;
+
+    } catch (IamportResponseException | IOException e) {
+
+      throw new CustomException(PAYMENT_ERROR);
+    }
+  }
+
+  @Transactional
+  public IamportResponse<Payment> cancelOrder(String impUid) {
+
+    try {
+
+      IamportResponse<Payment> response = iamportClient.paymentByImpUid(impUid);
+      Payment payment = response.getResponse();
+
+      Transaction transaction = transactionRepository.findByMerchantUid(payment.getMerchantUid())
+          .orElseThrow(() -> new CustomException(NOT_FOUND_ORDER));
+
+      if (!payment.getStatus().equals("paid") || !transaction.getPaymentStatus()
+          .equals(CANCEL_REQUEST)) {
+
+        throw new CustomException(INVALID_STATUS);
+      }
+
+      CancelData cancelData = new CancelData(impUid, true);
+
+      IamportResponse<Payment> cancelResponse = iamportClient.cancelPaymentByImpUid(cancelData);
+
+      if (cancelResponse.getResponse() == null || !cancelResponse.getResponse().getStatus()
+          .equals("cancelled")) {
+
+        throw new CustomException(FAILURE_CANCEL);
+      }
+
+      transaction.setPaymentStatus(CANCELED);
+      transactionRepository.save(transaction);
+
+      return cancelResponse;
+
+    } catch (IamportResponseException | IOException e) {
+
+      throw new CustomException(PAYMENT_ERROR);
+    }
+  }
+
+  @Transactional(readOnly = true)
+  public Page<TransactionBuyerListDto> getBuyerPurchaseList(Pageable pageable, String token) {
+
+    Member member = jwtProvider.getMemberFromEmail(token);
+
+    Long memberId = member.getId();
+
+    Page<Transaction> transactionPage = transactionRepository.findByMemberId(memberId, pageable);
+
+    return transactionPage.map(transaction -> {
+
+      List<Item> items = new ArrayList<>(transaction.getItems());
+
+      return TransactionBuyerListDto.fromEntity(transaction, items);
+    });
+  }
+
+  public void updateBuyerPurchase(Long id, PaymentStatusType paymentStatus, String token) {
+
+    Member member = jwtProvider.getMemberFromEmail(token);
+
+    Transaction transaction = transactionRepository.findById(id)
+        .orElseThrow(() -> new CustomException(NOT_FOUND_ORDER));
+
+    if (!member.getId().equals(transaction.getMember().getId())) {
+
+      throw new CustomException(NOT_PERMISSION);
+    }
+
+    if (paymentStatus == CANCEL_REQUEST) {
+
+      if (transaction.getPaymentStatus() == PAID || transaction.getPaymentStatus() == ORDER_CONFIRMED) {
+
+        transaction.setPaymentStatus(CANCEL_REQUEST);
+      }
+    } else {
+
+      switch (paymentStatus) {
+        case EXCHANGE_REQUEST:
+        case NOT_RECEIVED:
+        case PURCHASE_CONFIRMED:
+
+          if (transaction.getPaymentStatus() == DELIVERED) {
+            transaction.setPaymentStatus(paymentStatus);
+          } else {
+            throw new CustomException(INVALID_STATUS);
+          }
+          break;
+
+        default:
+          throw new CustomException(INVALID_STATUS);
+      }
+    }
+
+    transactionRepository.save(transaction);
+  }
+
+  @Transactional(readOnly = true)
+  public Page<TransactionSellerListDto> getSellerPurchaseList(Pageable pageable, String token) {
+
+    Member member = jwtProvider.getMemberFromEmail(token);
+
+    if (member.getRole() != SELLER) {
+
+      throw new CustomException(NOT_PERMISSION);
+    }
+
+    Long roasterId = member.getRoaster().getId();
+
+    Page<Transaction> transactionPage = transactionRepository.findByRoasterId(roasterId, pageable);
+
+    return transactionPage.map(transaction -> {
+
+      List<Item> items = new ArrayList<>(transaction.getItems());
+
+      return TransactionSellerListDto.fromEntity(transaction, items);
+    });
+  }
+
+  public void updateSellerPurchase(Long id, PaymentStatusType paymentStatus, String token) {
+
+    Member member = jwtProvider.getMemberFromEmail(token);
+
+    if (member.getRole() != SELLER) {
+
+      throw new CustomException(NOT_PERMISSION);
+    }
+
+    Transaction transaction = transactionRepository.findById(id)
+        .orElseThrow(() -> new CustomException(NOT_FOUND_ORDER));
+
+    if (!member.getRoaster().getId().equals(transaction.getRoaster().getId())) {
+
+      throw new CustomException(NOT_PERMISSION);
+    }
+
+    if (paymentStatus == ORDER_CONFIRMED && transaction.getPaymentStatus() == PAID) {
+
+      transaction.setPaymentStatus(ORDER_CONFIRMED);
+
+    } else if (paymentStatus == PREPARE && transaction.getPaymentStatus() == ORDER_CONFIRMED) {
+
+      transaction.setPaymentStatus(PREPARE);
+
+    } else if (paymentStatus == DELIVERY && transaction.getPaymentStatus() == PREPARE) {
+
+      transaction.setPaymentStatus(DELIVERY);
+
+    } else if (paymentStatus == DELIVERED && transaction.getPaymentStatus() == DELIVERY) {
+
+      transaction.setPaymentStatus(DELIVERED);
+
+    } else if (paymentStatus == EXCHANGED && transaction.getPaymentStatus() == EXCHANGE_REQUEST) {
+
+      transaction.setPaymentStatus(EXCHANGED);
+
+    } else {
+
+      throw new CustomException(INVALID_STATUS);
+    }
+
+    transactionRepository.save(transaction);
+  }
+}

--- a/src/main/java/com/coffee/coffeeserviceproject/order/transaction/type/PaymentMethodType.java
+++ b/src/main/java/com/coffee/coffeeserviceproject/order/transaction/type/PaymentMethodType.java
@@ -1,0 +1,5 @@
+package com.coffee.coffeeserviceproject.order.transaction.type;
+
+public enum PaymentMethodType {
+  CARD, BANK, PHONE, SIMPLE
+}

--- a/src/main/java/com/coffee/coffeeserviceproject/order/transaction/type/PaymentStatusType.java
+++ b/src/main/java/com/coffee/coffeeserviceproject/order/transaction/type/PaymentStatusType.java
@@ -1,0 +1,16 @@
+package com.coffee.coffeeserviceproject.order.transaction.type;
+
+public enum PaymentStatusType {
+  READY,
+  PAID,
+  ORDER_CONFIRMED,
+  PREPARE,
+  DELIVERY,
+  DELIVERED,
+  PURCHASE_CONFIRMED,
+  CANCEL_REQUEST,
+  CANCELED,
+  EXCHANGE_REQUEST,
+  EXCHANGED,
+  NOT_RECEIVED
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -17,3 +17,6 @@ spring.mail.properties.mail.smtp.starttls.enable=true
 jwt.secret=${JWT_SECRET}
 
 spring.elasticsearch.uris=http://localhost:9200
+
+imp.v1.api.key=${PAYMENT_API_KEY}
+imp.v1.api.secret=${PAYMENT_API_SECRET}

--- a/src/test/java/com/coffee/coffeeserviceproject/order/cart/service/CartServiceTest.java
+++ b/src/test/java/com/coffee/coffeeserviceproject/order/cart/service/CartServiceTest.java
@@ -1,0 +1,395 @@
+package com.coffee.coffeeserviceproject.order.cart.service;
+
+import static com.coffee.coffeeserviceproject.bean.type.PurchaseStatus.IMPOSSIBLE;
+import static com.coffee.coffeeserviceproject.bean.type.PurchaseStatus.POSSIBLE;
+import static com.coffee.coffeeserviceproject.common.type.ErrorCode.MAX_QUANTITY;
+import static com.coffee.coffeeserviceproject.common.type.ErrorCode.NOT_AVAILABLE_PURCHASE;
+import static com.coffee.coffeeserviceproject.common.type.ErrorCode.NOT_FOUND_BEAN;
+import static com.coffee.coffeeserviceproject.common.type.ErrorCode.NOT_FOUND_CART;
+import static com.coffee.coffeeserviceproject.common.type.ErrorCode.NOT_PERMISSION;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.coffee.coffeeserviceproject.bean.entity.Bean;
+import com.coffee.coffeeserviceproject.bean.repository.BeanRepository;
+import com.coffee.coffeeserviceproject.common.exception.CustomException;
+import com.coffee.coffeeserviceproject.configuration.JwtProvider;
+import com.coffee.coffeeserviceproject.member.entity.Member;
+import com.coffee.coffeeserviceproject.member.entity.Roaster;
+import com.coffee.coffeeserviceproject.order.cart.dto.CartDto;
+import com.coffee.coffeeserviceproject.order.cart.dto.CartListDto;
+import com.coffee.coffeeserviceproject.order.cart.dto.CartUpdateDto;
+import com.coffee.coffeeserviceproject.order.cart.entity.Cart;
+import com.coffee.coffeeserviceproject.order.cart.repository.CartRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CartServiceTest {
+
+  @Mock
+  private CartRepository cartRepository;
+
+  @Mock
+  private JwtProvider jwtProvider;
+
+  @Mock
+  private BeanRepository beanRepository;
+
+  @InjectMocks
+  private CartService cartService;
+
+  private Member member;
+  private Bean bean;
+
+  @BeforeEach
+  void setUp() {
+
+    member = new Member();
+    bean = new Bean();
+    bean.setId(1L);
+    bean.setPurchaseStatus(POSSIBLE);
+    bean.setPrice(1000L);
+
+  }
+
+  @Test
+  void addCart_Success() {
+    // given
+    CartDto cartDto = new CartDto(5, null);
+    String token = "token";
+    when(jwtProvider.getMemberFromEmail(token)).thenReturn(member);
+    when(beanRepository.findById(bean.getId())).thenReturn(Optional.of(bean));
+    when(cartRepository.findByMemberAndBean(member, bean)).thenReturn(null);
+    // when
+    cartService.addCart(bean.getId(), cartDto, token);
+    // then
+    verify(cartRepository).save(any());
+  }
+
+  @Test
+  void addCart_Success_NewCart() {
+    // given
+    CartDto cartDto = new CartDto(5, null);
+    String token = "token";
+    Cart cart = new Cart();
+    cart.setCartId(2L);
+    when(jwtProvider.getMemberFromEmail(token)).thenReturn(member);
+    when(beanRepository.findById(bean.getId())).thenReturn(Optional.of(bean));
+    when(cartRepository.findByMemberAndBean(member, bean)).thenReturn(cart);
+    // when
+    cartService.addCart(bean.getId(), cartDto, token);
+    // then
+    verify(cartRepository).save(any());
+  }
+
+  @Test
+  void addCart_Success_AddQuantity() {
+    // given
+    CartDto cartDto = new CartDto(50, null);
+    String token = "token";
+    Cart cart = new Cart();
+    cart.setQuantity(50);
+    when(jwtProvider.getMemberFromEmail(token)).thenReturn(member);
+    when(beanRepository.findById(bean.getId())).thenReturn(Optional.of(bean));
+    when(cartRepository.findByMemberAndBean(member, bean)).thenReturn(cart);
+    // when
+    cartService.addCart(bean.getId(), cartDto, token);
+    // then
+    verify(cartRepository).save(any());
+    assertEquals(100, cart.getQuantity());
+  }
+
+  @Test
+  void addCart_Failure_NotFoundBean() {
+    // given
+    CartDto cartDto = new CartDto(5, null);
+    String token = "token";
+    when(jwtProvider.getMemberFromEmail(token)).thenReturn(member);
+    when(beanRepository.findById(bean.getId())).thenReturn(Optional.empty());
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> cartService.addCart(bean.getId(), cartDto, token));
+    // then
+    assertEquals(NOT_FOUND_BEAN, e.getErrorCode());
+  }
+
+  @Test
+  void addCart_Failure_NotAvailablePurchase() {
+    // given
+    CartDto cartDto = new CartDto(5, null);
+    String token = "token";
+    bean.setPurchaseStatus(IMPOSSIBLE);
+    when(jwtProvider.getMemberFromEmail(token)).thenReturn(member);
+    when(beanRepository.findById(bean.getId())).thenReturn(Optional.of(bean));
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> cartService.addCart(bean.getId(), cartDto, token));
+    // then
+    assertEquals(NOT_AVAILABLE_PURCHASE, e.getErrorCode());
+  }
+
+  @Test
+  void addCart_Failure_MaxQuantity() {
+    // given
+    CartDto cartDto = new CartDto(101, null);
+    String token = "token";
+    when(jwtProvider.getMemberFromEmail(token)).thenReturn(member);
+    when(beanRepository.findById(bean.getId())).thenReturn(Optional.of(bean));
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> cartService.addCart(bean.getId(), cartDto, token));
+    // then
+    assertEquals(MAX_QUANTITY, e.getErrorCode());
+  }
+
+  @Test
+  void addCart_Failure_AddCartMaxQuantity() {
+    // given
+    CartDto cartDto = new CartDto(50, null);
+    String token = "token";
+    Cart cart = new Cart();
+    cart.setQuantity(51);
+    when(jwtProvider.getMemberFromEmail(token)).thenReturn(member);
+    when(beanRepository.findById(bean.getId())).thenReturn(Optional.of(bean));
+    when(cartRepository.findByMemberAndBean(member, bean)).thenReturn(cart);
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> cartService.addCart(bean.getId(), cartDto, token));
+    // then
+    assertEquals(MAX_QUANTITY, e.getErrorCode());
+  }
+
+  @Test
+  void getCart_Success() {
+    // given
+    String token = "token";
+
+    Roaster roaster1 = new Roaster();
+    Roaster roaster2 = new Roaster();
+    Roaster roaster3 = new Roaster();
+
+    roaster1.setRoasterName("1번");
+    roaster2.setRoasterName("2번");
+    roaster3.setRoasterName("3번");
+
+    Member member1 = new Member();
+    Member member2 = new Member();
+    Member member3 = new Member();
+
+    member1.setRoaster(roaster1);
+    member2.setRoaster(roaster2);
+    member3.setRoaster(roaster3);
+
+    Bean bean1 = new Bean();
+    Bean bean2 = new Bean();
+    Bean bean3 = new Bean();
+
+    bean1.setMember(member1);
+    bean2.setMember(member2);
+    bean3.setMember(member3);
+
+    Cart cart1 = new Cart();
+    Cart cart2 = new Cart();
+    Cart cart3 = new Cart();
+
+    cart1.setCartId(1L);
+    cart1.setBean(bean1);
+    cart2.setCartId(2L);
+    cart2.setBean(bean2);
+    cart3.setCartId(3L);
+    cart3.setBean(bean3);
+
+    when(jwtProvider.getMemberFromEmail(token)).thenReturn(member);
+    when(cartRepository.findAllByMemberId(member.getId())).thenReturn(List.of(cart1, cart2, cart3));
+
+    // when
+    List<CartListDto> cartList = cartService.getCart(token);
+    // then
+    assertEquals(3, cartList.size());
+    assertEquals("1번", cartList.get(0).getRoasterName());
+    assertEquals("2번", cartList.get(1).getRoasterName());
+    assertEquals("3번", cartList.get(2).getRoasterName());
+  }
+
+  @Test
+  void getCart_Success_EmptyList() {
+    // given
+    String token = "token";
+    when(jwtProvider.getMemberFromEmail(token)).thenReturn(member);
+    when(cartRepository.findAllByMemberId(member.getId())).thenReturn(List.of());
+    // when
+    List<CartListDto> cartList = cartService.getCart(token);
+    // then
+    assertTrue(cartList.isEmpty());
+  }
+
+  @Test
+  void updateCart_Success() {
+    // given
+    member.setId(1L);
+
+    Cart cart = new Cart();
+    cart.setCartId(1L);
+    cart.setQuantity(3);
+    cart.setRequestNote("fine 분쇄로 주세요");
+    cart.setMember(member);
+
+    CartUpdateDto cartUpdateDto = new CartUpdateDto();
+    cartUpdateDto.setQuantity(5);
+    cartUpdateDto.setRequestNote("홀빈으로 주세요");
+
+    String token = "token";
+
+    when(jwtProvider.getMemberFromEmail(token)).thenReturn(member);
+    when(cartRepository.findById(cart.getCartId())).thenReturn(Optional.of(cart));
+    // when
+    cartService.updateCart(cart.getCartId(), cartUpdateDto, token);
+    // then
+    assertEquals(5, cart.getQuantity());
+    assertEquals("홀빈으로 주세요", cart.getRequestNote());
+    verify(cartRepository).save(any());
+  }
+
+  @Test
+  void updateCart_Success_OnlyRequestNote() {
+    // given
+    member.setId(1L);
+
+    Cart cart = new Cart();
+    cart.setCartId(1L);
+    cart.setQuantity(3);
+    cart.setRequestNote("fine 분쇄로 주세요");
+    cart.setMember(member);
+
+    CartUpdateDto cartUpdateDto = new CartUpdateDto();
+    cartUpdateDto.setRequestNote("홀빈으로 주세요");
+
+    String token = "token";
+
+    when(jwtProvider.getMemberFromEmail(token)).thenReturn(member);
+    when(cartRepository.findById(cart.getCartId())).thenReturn(Optional.of(cart));
+    // when
+    cartService.updateCart(cart.getCartId(), cartUpdateDto, token);
+    // then
+    assertEquals(3, cart.getQuantity());
+    assertEquals("홀빈으로 주세요", cart.getRequestNote());
+    verify(cartRepository).save(any());
+  }
+
+  @Test
+  void updateCart_Success_OnlyQuantity() {
+    // given
+    member.setId(1L);
+
+    Cart cart = new Cart();
+    cart.setCartId(1L);
+    cart.setQuantity(3);
+    cart.setRequestNote("fine 분쇄로 주세요");
+    cart.setMember(member);
+
+    CartUpdateDto cartUpdateDto = new CartUpdateDto();
+    cartUpdateDto.setQuantity(5);
+
+    String token = "token";
+
+    when(jwtProvider.getMemberFromEmail(token)).thenReturn(member);
+    when(cartRepository.findById(cart.getCartId())).thenReturn(Optional.of(cart));
+    // when
+    cartService.updateCart(cart.getCartId(), cartUpdateDto, token);
+    // then
+    assertEquals(5, cart.getQuantity());
+    assertEquals("fine 분쇄로 주세요", cart.getRequestNote());
+    verify(cartRepository).save(any());
+  }
+
+  @Test
+  void updateCart_Failure_NotFoundCart() {
+    // given
+    Long cartId = 1L;
+    CartUpdateDto cartUpdateDto = new CartUpdateDto();
+    String token = "token";
+
+    when(jwtProvider.getMemberFromEmail(token)).thenReturn(member);
+    when(cartRepository.findById(cartId)).thenReturn(Optional.empty());
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> cartService.updateCart(cartId, cartUpdateDto, token));
+    // then
+    assertEquals(NOT_FOUND_CART, e.getErrorCode());
+    verify(cartRepository, never()).save(any());
+  }
+
+  @Test
+  void deleteCart_Success() {
+    // given
+    member.setId(1L);
+
+    Cart cart = new Cart();
+    cart.setCartId(1L);
+    cart.setMember(member);
+
+    String token = "token";
+
+    when(jwtProvider.getMemberFromEmail(token)).thenReturn(member);
+    when(cartRepository.findById(cart.getCartId())).thenReturn(Optional.of(cart));
+    // when
+    cartService.deleteCart(cart.getCartId(), token);
+    // then
+    verify(cartRepository).delete(cart);
+  }
+
+  @Test
+  void deleteCart_Failure_NotFoundCart() {
+    // given
+    member.setId(1L);
+
+    String token = "token";
+
+    Cart cart = new Cart();
+    cart.setCartId(1L);
+
+    when(jwtProvider.getMemberFromEmail(token)).thenReturn(member);
+    when(cartRepository.findById(cart.getCartId())).thenReturn(Optional.empty());
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> cartService.deleteCart(cart.getCartId(), token));
+    // then
+    assertEquals(NOT_FOUND_CART, e.getErrorCode());
+    verify(cartRepository, never()).delete(any());
+  }
+
+  @Test
+  void deleteCart_Failure_NotPermission() {
+    // given
+    String token = "token";
+
+    member.setId(1L);
+    Member otherMember = new Member();
+    otherMember.setId(2L);
+
+    Cart cart = new Cart();
+    cart.setCartId(1L);
+    cart.setMember(member);
+
+    when(jwtProvider.getMemberFromEmail(token)).thenReturn(otherMember);
+    when(cartRepository.findById(cart.getCartId())).thenReturn(Optional.of(cart));
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> cartService.deleteCart(cart.getCartId(), token));
+    // then
+    assertEquals(NOT_PERMISSION, e.getErrorCode());
+    verify(cartRepository, never()).delete(any());
+  }
+}

--- a/src/test/java/com/coffee/coffeeserviceproject/order/cart/service/CartServiceTest.java
+++ b/src/test/java/com/coffee/coffeeserviceproject/order/cart/service/CartServiceTest.java
@@ -245,6 +245,7 @@ class CartServiceTest {
     cart.setQuantity(3);
     cart.setRequestNote("fine 분쇄로 주세요");
     cart.setMember(member);
+    cart.setBean(bean);
 
     CartUpdateDto cartUpdateDto = new CartUpdateDto();
     cartUpdateDto.setQuantity(5);
@@ -272,6 +273,7 @@ class CartServiceTest {
     cart.setQuantity(3);
     cart.setRequestNote("fine 분쇄로 주세요");
     cart.setMember(member);
+    cart.setBean(bean);
 
     CartUpdateDto cartUpdateDto = new CartUpdateDto();
     cartUpdateDto.setRequestNote("홀빈으로 주세요");
@@ -298,6 +300,7 @@ class CartServiceTest {
     cart.setQuantity(3);
     cart.setRequestNote("fine 분쇄로 주세요");
     cart.setMember(member);
+    cart.setBean(bean);
 
     CartUpdateDto cartUpdateDto = new CartUpdateDto();
     cartUpdateDto.setQuantity(5);

--- a/src/test/java/com/coffee/coffeeserviceproject/order/transaction/service/TransactionServiceTest.java
+++ b/src/test/java/com/coffee/coffeeserviceproject/order/transaction/service/TransactionServiceTest.java
@@ -1,0 +1,1056 @@
+package com.coffee.coffeeserviceproject.order.transaction.service;
+
+import static com.coffee.coffeeserviceproject.bean.type.PurchaseStatus.IMPOSSIBLE;
+import static com.coffee.coffeeserviceproject.bean.type.PurchaseStatus.POSSIBLE;
+import static com.coffee.coffeeserviceproject.common.type.ErrorCode.FAILURE_CANCEL;
+import static com.coffee.coffeeserviceproject.common.type.ErrorCode.INVALID_AMOUNT;
+import static com.coffee.coffeeserviceproject.common.type.ErrorCode.INVALID_STATUS;
+import static com.coffee.coffeeserviceproject.common.type.ErrorCode.NOT_AVAILABLE_PURCHASE;
+import static com.coffee.coffeeserviceproject.common.type.ErrorCode.NOT_FOUND_BEAN;
+import static com.coffee.coffeeserviceproject.common.type.ErrorCode.NOT_FOUND_ORDER;
+import static com.coffee.coffeeserviceproject.common.type.ErrorCode.NOT_PERMISSION;
+import static com.coffee.coffeeserviceproject.common.type.ErrorCode.PAYMENT_ERROR;
+import static com.coffee.coffeeserviceproject.common.type.ErrorCode.PRICE_CHANGE;
+import static com.coffee.coffeeserviceproject.member.type.RoleType.BUYER;
+import static com.coffee.coffeeserviceproject.member.type.RoleType.SELLER;
+import static com.coffee.coffeeserviceproject.order.transaction.type.PaymentStatusType.CANCELED;
+import static com.coffee.coffeeserviceproject.order.transaction.type.PaymentStatusType.CANCEL_REQUEST;
+import static com.coffee.coffeeserviceproject.order.transaction.type.PaymentStatusType.DELIVERED;
+import static com.coffee.coffeeserviceproject.order.transaction.type.PaymentStatusType.EXCHANGED;
+import static com.coffee.coffeeserviceproject.order.transaction.type.PaymentStatusType.EXCHANGE_REQUEST;
+import static com.coffee.coffeeserviceproject.order.transaction.type.PaymentStatusType.NOT_RECEIVED;
+import static com.coffee.coffeeserviceproject.order.transaction.type.PaymentStatusType.ORDER_CONFIRMED;
+import static com.coffee.coffeeserviceproject.order.transaction.type.PaymentStatusType.PAID;
+import static com.coffee.coffeeserviceproject.order.transaction.type.PaymentStatusType.PURCHASE_CONFIRMED;
+import static com.coffee.coffeeserviceproject.order.transaction.type.PaymentStatusType.READY;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.coffee.coffeeserviceproject.bean.entity.Bean;
+import com.coffee.coffeeserviceproject.bean.repository.BeanRepository;
+import com.coffee.coffeeserviceproject.common.exception.CustomException;
+import com.coffee.coffeeserviceproject.configuration.JwtProvider;
+import com.coffee.coffeeserviceproject.member.entity.Member;
+import com.coffee.coffeeserviceproject.member.entity.Roaster;
+import com.coffee.coffeeserviceproject.member.repository.RoasterRepository;
+import com.coffee.coffeeserviceproject.order.cart.entity.Cart;
+import com.coffee.coffeeserviceproject.order.cart.repository.CartRepository;
+import com.coffee.coffeeserviceproject.order.transaction.dto.TransactionBuyerListDto;
+import com.coffee.coffeeserviceproject.order.transaction.dto.TransactionDto;
+import com.coffee.coffeeserviceproject.order.transaction.dto.TransactionSellerListDto;
+import com.coffee.coffeeserviceproject.order.transaction.entity.Item;
+import com.coffee.coffeeserviceproject.order.transaction.entity.Transaction;
+import com.coffee.coffeeserviceproject.order.transaction.repository.TransactionRepository;
+import com.siot.IamportRestClient.IamportClient;
+import com.siot.IamportRestClient.exception.IamportResponseException;
+import com.siot.IamportRestClient.request.CancelData;
+import com.siot.IamportRestClient.response.IamportResponse;
+import com.siot.IamportRestClient.response.Payment;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+@ExtendWith(MockitoExtension.class)
+class TransactionServiceTest {
+
+  @Mock
+  private IamportClient iamportClient;
+
+  @Mock
+  private JwtProvider jwtProvider;
+
+  @Mock
+  private TransactionRepository transactionRepository;
+
+  @Mock
+  private BeanRepository beanRepository;
+
+  @Mock
+  private CartRepository cartRepository;
+
+  @Mock
+  private RoasterRepository roasterRepository;
+
+  @InjectMocks
+  private TransactionService transactionService;
+
+  private Member member;
+  private Member member2;
+  private Roaster roaster;
+  private Bean bean;
+  private Bean bean2;
+  private Bean bean3;
+  private Cart cart;
+  private Cart cart2;
+  private Cart cart3;
+  private Long totalPrice;
+
+  @BeforeEach
+  void setUp() {
+    member = new Member();
+    member.setId(1L);
+
+    roaster = new Roaster();
+    roaster.setId(1L);
+
+    member2 = new Member();
+    member2.setId(2L);
+    member2.setRoaster(roaster);
+    member2.setRole(SELLER);
+
+    bean = new Bean();
+    bean.setId(1L);
+    bean.setBeanName("1번 원두");
+    bean.setPrice(1000L);
+    bean.setPurchaseStatus(POSSIBLE);
+    bean.setMember(member2);
+
+    bean2 = new Bean();
+    bean2.setId(2L);
+    bean2.setBeanName("2번 원두");
+    bean2.setPrice(2000L);
+    bean2.setPurchaseStatus(POSSIBLE);
+    bean2.setMember(member2);
+
+    bean3 = new Bean();
+    bean3.setId(3L);
+    bean3.setBeanName("3번 원두");
+    bean3.setPrice(3000L);
+    bean3.setPurchaseStatus(POSSIBLE);
+    bean3.setMember(member2);
+
+    cart = new Cart();
+    cart.setCartId(1L);
+    cart.setMember(member);
+    cart.setBean(bean);
+    cart.setPriceAtAdded(bean.getPrice());
+    cart.setQuantity(1);
+
+    cart2 = new Cart();
+    cart2.setCartId(2L);
+    cart2.setMember(member);
+    cart2.setBean(bean2);
+    cart2.setPriceAtAdded(bean2.getPrice());
+    cart2.setQuantity(1);
+
+    cart3 = new Cart();
+    cart3.setCartId(3L);
+    cart3.setMember(member);
+    cart3.setBean(bean3);
+    cart3.setPriceAtAdded(bean3.getPrice());
+    cart3.setQuantity(1);
+
+    totalPrice = (cart.getPriceAtAdded() * cart.getQuantity()) +
+        (cart2.getPriceAtAdded() * cart2.getQuantity()) +
+        (cart3.getPriceAtAdded() * cart3.getQuantity());
+  }
+
+  @Test
+  void createOrder_Success() {
+    // given
+    String token = "token";
+
+    TransactionDto transactionDto = TransactionDto.builder()
+        .totalPrice(totalPrice)
+        .merchant_uid("merchant_uid")
+        .items(List.of(
+            Item.builder()
+                .beanId(cart.getBean().getId())
+                .quantity(cart.getQuantity())
+                .price(cart.getPriceAtAdded())
+                .build(),
+            Item.builder()
+                .beanId(cart2.getBean().getId())
+                .quantity(cart2.getQuantity())
+                .price(cart2.getPriceAtAdded())
+                .build(),
+            Item.builder()
+                .beanId(cart3.getBean().getId())
+                .quantity(cart3.getQuantity())
+                .price(cart3.getPriceAtAdded())
+                .build()
+        )).build();
+
+    when(jwtProvider.getMemberFromEmail(token)).thenReturn(member);
+    when(beanRepository.findById(bean.getId())).thenReturn(Optional.of(bean));
+    when(beanRepository.findById(bean2.getId())).thenReturn(Optional.of(bean2));
+    when(beanRepository.findById(bean3.getId())).thenReturn(Optional.of(bean3));
+    when(roasterRepository.findById(roaster.getId())).thenReturn(Optional.of(roaster));
+    // when
+    transactionService.createOrder(transactionDto, token);
+    // then
+    verify(transactionRepository).save(any());
+  }
+
+  @Test
+  void createOrder_Failure_NotFoundBean() {
+    // given
+    String token = "token";
+
+    TransactionDto transactionDto = TransactionDto.builder()
+        .totalPrice(totalPrice)
+        .merchant_uid("merchant_uid")
+        .items(List.of(
+            Item.builder()
+                .beanId(cart.getBean().getId())
+                .quantity(cart.getQuantity())
+                .price(cart.getPriceAtAdded())
+                .build(),
+            Item.builder()
+                .beanId(cart2.getBean().getId())
+                .quantity(cart2.getQuantity())
+                .price(cart2.getPriceAtAdded())
+                .build(),
+            Item.builder()
+                .beanId(cart3.getBean().getId())
+                .quantity(cart3.getQuantity())
+                .price(cart3.getPriceAtAdded())
+                .build(),
+            Item.builder()
+                .beanId(4L)
+                .build()
+        )).build();
+
+    when(jwtProvider.getMemberFromEmail(token)).thenReturn(member);
+    when(beanRepository.findById(bean.getId())).thenReturn(Optional.of(bean));
+    when(beanRepository.findById(bean2.getId())).thenReturn(Optional.of(bean2));
+    when(beanRepository.findById(bean3.getId())).thenReturn(Optional.of(bean3));
+    when(beanRepository.findById(4L)).thenReturn(Optional.empty());
+    when(roasterRepository.findById(roaster.getId())).thenReturn(Optional.of(roaster));
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> transactionService.createOrder(transactionDto, token));
+    // then
+    assertEquals(NOT_FOUND_BEAN, e.getErrorCode());
+    verify(transactionRepository, never()).save(any());
+  }
+
+  @Test
+  void createOrder_Failure_NotAvailablePurchase() {
+    // given
+    String token = "token";
+    bean.setPurchaseStatus(IMPOSSIBLE);
+
+    TransactionDto transactionDto = TransactionDto.builder()
+        .totalPrice(totalPrice)
+        .merchant_uid("merchant_uid")
+        .items(List.of(
+            Item.builder()
+                .beanId(cart.getBean().getId())
+                .quantity(cart.getQuantity())
+                .price(cart.getPriceAtAdded())
+                .build(),
+            Item.builder()
+                .beanId(cart2.getBean().getId())
+                .quantity(cart2.getQuantity())
+                .price(cart2.getPriceAtAdded())
+                .build(),
+            Item.builder()
+                .beanId(cart3.getBean().getId())
+                .quantity(cart3.getQuantity())
+                .price(cart3.getPriceAtAdded())
+                .build()
+        )).build();
+
+    when(jwtProvider.getMemberFromEmail(token)).thenReturn(member);
+    when(beanRepository.findById(bean.getId())).thenReturn(Optional.of(bean));
+    when(roasterRepository.findById(roaster.getId())).thenReturn(Optional.of(roaster));
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> transactionService.createOrder(transactionDto, token));
+    // then
+    assertEquals(NOT_AVAILABLE_PURCHASE, e.getErrorCode());
+    assertEquals("구매가 불가능한 상품입니다.-> " + bean.getBeanName(), e.getMessage());
+    verify(transactionRepository, never()).save(any());
+  }
+
+
+  @Test
+  void createOrder_Failure_PriceChange() {
+    // given
+    String token = "token";
+
+    TransactionDto transactionDto = TransactionDto.builder()
+        .totalPrice(totalPrice)
+        .merchant_uid("merchant_uid")
+        .items(List.of(
+            Item.builder()
+                .beanId(cart.getBean().getId())
+                .quantity(cart.getQuantity())
+                .price(cart.getPriceAtAdded())
+                .build(),
+            Item.builder()
+                .beanId(cart2.getBean().getId())
+                .quantity(cart2.getQuantity())
+                .price(cart2.getPriceAtAdded())
+                .build(),
+            Item.builder()
+                .beanId(cart3.getBean().getId())
+                .quantity(cart3.getQuantity())
+                .price(cart3.getPriceAtAdded())
+                .build()
+        )).build();
+
+    when(jwtProvider.getMemberFromEmail(token)).thenReturn(member);
+    when(beanRepository.findById(bean.getId())).thenReturn(Optional.of(bean));
+    when(roasterRepository.findById(roaster.getId())).thenReturn(Optional.of(roaster));
+
+    bean.setPrice(10000L);
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> transactionService.createOrder(transactionDto, token));
+    // then
+    assertEquals(PRICE_CHANGE, e.getErrorCode());
+    assertEquals("상품 가격이 변경되었습니다.-> " + bean.getBeanName(), e.getMessage());
+    verify(transactionRepository, never()).save(any());
+  }
+
+  @Test
+  void validateOrder_Success() throws IamportResponseException, IOException {
+    // given
+    String imp_uid = "imp_uid_123456789";
+    String merchant_uid = "merchant_uid_123456789";
+    Payment payment = mock(Payment.class);
+    totalPrice = (cart.getPriceAtAdded() * cart.getQuantity()) +
+        (cart2.getPriceAtAdded() * cart2.getQuantity());
+
+    when(payment.getStatus()).thenReturn("paid");
+    when(payment.getAmount()).thenReturn(BigDecimal.valueOf(totalPrice));
+    when(payment.getMerchantUid()).thenReturn(merchant_uid);
+
+    IamportResponse<Payment> response = mock(IamportResponse.class);
+    when(response.getResponse()).thenReturn(payment);
+    when(iamportClient.paymentByImpUid(imp_uid)).thenReturn(response);
+
+    Transaction transaction = Transaction.builder()
+        .transactionId(1L)
+        .member(member)
+        .merchantUid(merchant_uid)
+        .paymentStatus(READY)
+        .items(
+            List.of(
+                Item.builder()
+                    .beanId(cart.getBean().getId())
+                    .quantity(cart.getQuantity())
+                    .price(cart.getPriceAtAdded())
+                    .build(),
+                Item.builder()
+                    .beanId(cart2.getBean().getId())
+                    .quantity(cart2.getQuantity())
+                    .price(cart2.getPriceAtAdded())
+                    .build()
+            )).build();
+
+    when(transactionRepository.findByMerchantUid(payment.getMerchantUid())).thenReturn(
+        Optional.of(transaction));
+    // when
+    IamportResponse<Payment> iamportResponse = transactionService.validateOrder(imp_uid);
+    // then
+    assertNotNull(iamportResponse);
+    assertEquals("paid", iamportResponse.getResponse().getStatus());
+    assertEquals(merchant_uid, iamportResponse.getResponse().getMerchantUid());
+    assertEquals(PAID, transaction.getPaymentStatus());
+    assertEquals(totalPrice, transaction.getTotalPrice());
+    verify(transactionRepository).save(any());
+    for (Item item : transaction.getItems()) {
+      verify(cartRepository).deleteByBeanIdAndMemberId(item.getBeanId(), member.getId());
+    }
+  }
+
+  @Test
+  void validateOrder_Failure_InvalidStatus() throws IamportResponseException, IOException {
+    // given
+    String imp_uid = "imp_uid_123456789";
+    String merchant_uid = "merchant_uid_123456789";
+
+    Payment payment = mock(Payment.class);
+    when(payment.getMerchantUid()).thenReturn(merchant_uid);
+    when(payment.getStatus()).thenReturn("ready");
+
+    IamportResponse<Payment> response = mock(IamportResponse.class);
+    when(response.getResponse()).thenReturn(payment);
+    when(iamportClient.paymentByImpUid(imp_uid)).thenReturn(response);
+
+    Transaction transaction = new Transaction();
+
+    when(transactionRepository.findByMerchantUid(payment.getMerchantUid())).thenReturn(
+        Optional.of(transaction));
+
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> transactionService.validateOrder(imp_uid));
+    // then
+    assertEquals(INVALID_STATUS, e.getErrorCode());
+    verify(transactionRepository, never()).save(any());
+  }
+
+  @Test
+  void validateOrder_Failure_NotFoundOrder() throws IamportResponseException, IOException {
+    // given
+    String imp_uid = "imp_uid_123456789";
+    String merchant_uid = "merchant_uid_123456789";
+
+    Payment payment = mock(Payment.class);
+    when(payment.getMerchantUid()).thenReturn(merchant_uid);
+
+    IamportResponse<Payment> response = mock(IamportResponse.class);
+    when(response.getResponse()).thenReturn(payment);
+    when(iamportClient.paymentByImpUid(imp_uid)).thenReturn(response);
+    when(transactionRepository.findByMerchantUid(merchant_uid)).thenReturn(Optional.empty());
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> transactionService.validateOrder(imp_uid));
+    // then
+    assertEquals(NOT_FOUND_ORDER, e.getErrorCode());
+    verify(transactionRepository, never()).save(any());
+  }
+
+  @Test
+  void validateOrder_Failure_InvalidAmount() throws IamportResponseException, IOException {
+    // given
+    String imp_uid = "imp_uid_123456789";
+    String merchant_uid = "merchant_uid_123456789";
+    totalPrice = (cart.getPriceAtAdded() * cart.getQuantity()) +
+        (cart2.getPriceAtAdded() * cart2.getQuantity());
+
+    Payment payment = mock(Payment.class);
+    when(payment.getStatus()).thenReturn("paid");
+    when(payment.getAmount()).thenReturn(BigDecimal.valueOf(totalPrice - 1000));
+    when(payment.getMerchantUid()).thenReturn(merchant_uid);
+
+    IamportResponse<Payment> response = mock(IamportResponse.class);
+    when(response.getResponse()).thenReturn(payment);
+    when(iamportClient.paymentByImpUid(imp_uid)).thenReturn(response);
+
+    Transaction transaction = Transaction.builder()
+        .transactionId(1L)
+        .member(member)
+        .merchantUid(merchant_uid)
+        .paymentStatus(READY)
+        .items(
+            List.of(
+                Item.builder()
+                    .beanId(cart.getBean().getId())
+                    .quantity(cart.getQuantity())
+                    .price(cart.getPriceAtAdded())
+                    .build(),
+                Item.builder()
+                    .beanId(cart2.getBean().getId())
+                    .quantity(cart2.getQuantity())
+                    .price(cart2.getPriceAtAdded())
+                    .build()
+            )).build();
+
+    when(transactionRepository.findByMerchantUid(payment.getMerchantUid())).thenReturn(
+        Optional.of(transaction));
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> transactionService.validateOrder(imp_uid));
+    // then
+    assertEquals(INVALID_AMOUNT, e.getErrorCode());
+    verify(transactionRepository, never()).save(any());
+  }
+
+  @Test
+  void validateOrder_Failure_PaymentError_IamportResponse()
+      throws IamportResponseException, IOException {
+    // given
+    String imp_uid = "imp_uid_123456789";
+    when(iamportClient.paymentByImpUid(imp_uid)).thenThrow(IamportResponseException.class);
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> transactionService.validateOrder(imp_uid));
+    // then
+    assertEquals(PAYMENT_ERROR, e.getErrorCode());
+  }
+
+  @Test
+  void validateOrder_Failure_PaymentError_IOE()
+      throws IamportResponseException, IOException {
+    // given
+    String imp_uid = "imp_uid_123456789";
+    when(iamportClient.paymentByImpUid(imp_uid)).thenThrow(IOException.class);
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> transactionService.validateOrder(imp_uid));
+    // then
+    assertEquals(PAYMENT_ERROR, e.getErrorCode());
+  }
+
+  @Test
+  void cancelOrder_Success() throws IamportResponseException, IOException {
+    // given
+    String imp_uid = "imp_uid_123456789";
+    String merchant_uid = "merchant_uid_123456789";
+
+    Payment payment = mock(Payment.class);
+    when(payment.getStatus()).thenReturn("paid");
+    when(payment.getMerchantUid()).thenReturn(merchant_uid);
+
+    IamportResponse<Payment> response = mock(IamportResponse.class);
+    when(response.getResponse()).thenReturn(payment);
+    when(iamportClient.paymentByImpUid(imp_uid)).thenReturn(response);
+
+    IamportResponse<Payment> cancelResponse = mock(IamportResponse.class);
+
+    Payment cancelPayment = mock(Payment.class);
+    when(cancelPayment.getStatus()).thenReturn("cancelled");
+
+    when(cancelResponse.getResponse()).thenReturn(cancelPayment);
+    when(iamportClient.cancelPaymentByImpUid(any(CancelData.class))).thenReturn(cancelResponse);
+
+    Transaction transaction = Transaction.builder()
+        .transactionId(1L)
+        .member(member)
+        .merchantUid(merchant_uid)
+        .paymentStatus(CANCEL_REQUEST)
+        .build();
+
+    when(transactionRepository.findByMerchantUid(payment.getMerchantUid())).thenReturn(
+        Optional.of(transaction));
+    // when
+    transactionService.cancelOrder(imp_uid);
+    // then
+    assertEquals(CANCELED, transaction.getPaymentStatus());
+    verify(transactionRepository).save(any());
+  }
+
+  @Test
+  void cancelOrder_Failure_NotFoundOrder() throws IamportResponseException, IOException {
+    // given
+    String imp_uid = "imp_uid_123456789";
+
+    Payment payment = mock(Payment.class);
+
+    IamportResponse<Payment> response = mock(IamportResponse.class);
+    when(response.getResponse()).thenReturn(payment);
+    when(iamportClient.paymentByImpUid(imp_uid)).thenReturn(response);
+
+    when(transactionRepository.findByMerchantUid(payment.getMerchantUid())).thenReturn(
+        Optional.empty());
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> transactionService.cancelOrder(imp_uid));
+    // then
+    assertEquals(NOT_FOUND_ORDER, e.getErrorCode());
+    verify(transactionRepository, never()).save(any());
+  }
+
+  @Test
+  void cancelOrder_Failure_InvalidStatus() throws IamportResponseException, IOException {
+    // given
+    String imp_uid = "imp_uid_123456789";
+
+    Payment payment = mock(Payment.class);
+    when(payment.getStatus()).thenReturn("paid");
+
+    IamportResponse<Payment> response = mock(IamportResponse.class);
+    when(response.getResponse()).thenReturn(payment);
+    when(iamportClient.paymentByImpUid(imp_uid)).thenReturn(response);
+
+    Transaction transaction = Transaction.builder()
+        .transactionId(1L)
+        .member(member)
+        .paymentStatus(READY)
+        .build();
+
+    when(transactionRepository.findByMerchantUid(payment.getMerchantUid())).thenReturn(
+        Optional.of(transaction));
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> transactionService.cancelOrder(imp_uid));
+    // then
+    assertEquals(INVALID_STATUS, e.getErrorCode());
+    verify(transactionRepository, never()).save(any());
+  }
+
+  @Test
+  void cancelOrder_Failure_FailureCancel() throws IamportResponseException, IOException {
+    // given
+    String imp_uid = "imp_uid_123456789";
+    String merchant_uid = "merchant_uid_123456789";
+
+    Payment payment = mock(Payment.class);
+    when(payment.getStatus()).thenReturn("paid");
+    when(payment.getMerchantUid()).thenReturn(merchant_uid);
+
+    IamportResponse<Payment> response = mock(IamportResponse.class);
+    when(response.getResponse()).thenReturn(payment);
+    when(iamportClient.paymentByImpUid(imp_uid)).thenReturn(response);
+
+    IamportResponse<Payment> cancelResponse = mock(IamportResponse.class);
+
+    Payment cancelPayment = mock(Payment.class);
+    when(cancelPayment.getStatus()).thenReturn("paid");
+
+    when(cancelResponse.getResponse()).thenReturn(cancelPayment);
+    when(iamportClient.cancelPaymentByImpUid(any(CancelData.class))).thenReturn(cancelResponse);
+
+    Transaction transaction = Transaction.builder()
+        .transactionId(1L)
+        .member(member)
+        .merchantUid(merchant_uid)
+        .paymentStatus(CANCEL_REQUEST)
+        .build();
+
+    when(transactionRepository.findByMerchantUid(payment.getMerchantUid())).thenReturn(
+        Optional.of(transaction));
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> transactionService.cancelOrder(imp_uid));
+    // then
+    assertEquals(FAILURE_CANCEL, e.getErrorCode());
+    verify(transactionRepository, never()).save(any());
+  }
+
+  @Test
+  void getBuyerPurchaseList_Success() {
+    // given
+    String token = "token";
+    Pageable pageable = Pageable.ofSize(10);
+
+    Transaction transaction = Transaction.builder()
+        .transactionId(1L)
+        .member(member)
+        .paymentStatus(PAID)
+        .items(
+            List.of(
+                Item.builder()
+                    .beanId(cart.getBean().getId())
+                    .quantity(cart.getQuantity())
+                    .price(cart.getPriceAtAdded())
+                    .build(),
+                Item.builder()
+                    .beanId(cart2.getBean().getId())
+                    .quantity(cart2.getQuantity())
+                    .price(cart2.getPriceAtAdded())
+                    .build()
+            )).build();
+
+    Page<Transaction> transactionPage = new PageImpl<>(List.of(transaction));
+    when(jwtProvider.getMemberFromEmail(token)).thenReturn(member);
+    when(transactionRepository.findByMemberId(member.getId(), pageable)).thenReturn(
+        transactionPage);
+    // when
+    Page<TransactionBuyerListDto> transactionBuyerListDtoPage = transactionService.getBuyerPurchaseList(
+        pageable, token);
+    // then
+    assertNotNull(transactionBuyerListDtoPage);
+    assertEquals(1, transactionBuyerListDtoPage.getTotalElements());
+  }
+
+  @Test
+  void getBuyerPurchaseList_Success_EmptyList() {
+    // given
+    String token = "token";
+    Pageable pageable = Pageable.ofSize(10);
+
+    Page<Transaction> transactionPage = new PageImpl<>(List.of());
+    when(jwtProvider.getMemberFromEmail(token)).thenReturn(member);
+    when(transactionRepository.findByMemberId(member.getId(), pageable)).thenReturn(
+        transactionPage);
+    // when
+    Page<TransactionBuyerListDto> transactionBuyerListDtoPage = transactionService.getBuyerPurchaseList(
+        pageable, token);
+    // then
+    assertNotNull(transactionBuyerListDtoPage);
+    assertTrue(transactionBuyerListDtoPage.isEmpty());
+  }
+
+  @Test
+  void updateBuyerPurchaseList_Success_CancelRequest() {
+    // given
+    String token = "token";
+
+    Transaction transaction = Transaction.builder()
+        .transactionId(1L)
+        .member(member)
+        .paymentStatus(PAID)
+        .items(
+            List.of(
+                Item.builder()
+                    .beanId(cart.getBean().getId())
+                    .quantity(cart.getQuantity())
+                    .price(cart.getPriceAtAdded())
+                    .build(),
+                Item.builder()
+                    .beanId(cart2.getBean().getId())
+                    .quantity(cart2.getQuantity())
+                    .price(cart2.getPriceAtAdded())
+                    .build()
+            )).build();
+
+    when(jwtProvider.getMemberFromEmail(token)).thenReturn(member);
+    when(transactionRepository.findById(transaction.getTransactionId())).thenReturn(
+        Optional.of(transaction));
+    // when
+    transactionService.updateBuyerPurchase(transaction.getTransactionId(), CANCEL_REQUEST, token);
+    // then
+    verify(transactionRepository).save(any());
+    assertEquals(CANCEL_REQUEST, transaction.getPaymentStatus());
+  }
+
+  @Test
+  void updateBuyerPurchaseList_Success_PurchaseConfirmed() {
+    // given
+    String token = "token";
+
+    Transaction transaction = Transaction.builder()
+        .transactionId(1L)
+        .member(member)
+        .paymentStatus(DELIVERED)
+        .items(
+            List.of(
+                Item.builder()
+                    .beanId(cart.getBean().getId())
+                    .quantity(cart.getQuantity())
+                    .price(cart.getPriceAtAdded())
+                    .build(),
+                Item.builder()
+                    .beanId(cart2.getBean().getId())
+                    .quantity(cart2.getQuantity())
+                    .price(cart2.getPriceAtAdded())
+                    .build()
+            )).build();
+
+    when(jwtProvider.getMemberFromEmail(token)).thenReturn(member);
+    when(transactionRepository.findById(transaction.getTransactionId())).thenReturn(
+        Optional.of(transaction));
+    // when
+    transactionService.updateBuyerPurchase(transaction.getTransactionId(), PURCHASE_CONFIRMED,
+        token);
+    // then
+    verify(transactionRepository).save(any());
+    assertEquals(PURCHASE_CONFIRMED, transaction.getPaymentStatus());
+  }
+
+  @Test
+  void updateBuyerPurchaseList_Failure_NotPermission() {
+    // given
+    String token = "token";
+
+    Transaction transaction = Transaction.builder()
+        .transactionId(1L)
+        .member(member)
+        .paymentStatus(PAID)
+        .items(
+            List.of(
+                Item.builder()
+                    .beanId(cart.getBean().getId())
+                    .quantity(cart.getQuantity())
+                    .price(cart.getPriceAtAdded())
+                    .build(),
+                Item.builder()
+                    .beanId(cart2.getBean().getId())
+                    .quantity(cart2.getQuantity())
+                    .price(cart2.getPriceAtAdded())
+                    .build()
+            )).build();
+
+    when(jwtProvider.getMemberFromEmail(token)).thenReturn(member2);
+    when(transactionRepository.findById(transaction.getTransactionId())).thenReturn(
+        Optional.of(transaction));
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> transactionService.updateBuyerPurchase(
+            transaction.getTransactionId(), CANCEL_REQUEST, token));
+    // then
+    verify(transactionRepository, never()).save(any());
+    assertEquals(NOT_PERMISSION, e.getErrorCode());
+  }
+
+  @Test
+  void updateBuyerPurchaseList_Failure_InvalidStatus() {
+    // given
+    String token = "token";
+
+    Transaction transaction = Transaction.builder()
+        .transactionId(1L)
+        .member(member)
+        .paymentStatus(PAID)
+        .items(
+            List.of(
+                Item.builder()
+                    .beanId(cart.getBean().getId())
+                    .quantity(cart.getQuantity())
+                    .price(cart.getPriceAtAdded())
+                    .build(),
+                Item.builder()
+                    .beanId(cart2.getBean().getId())
+                    .quantity(cart2.getQuantity())
+                    .price(cart2.getPriceAtAdded())
+                    .build()
+            )).build();
+
+    when(jwtProvider.getMemberFromEmail(token)).thenReturn(member);
+    when(transactionRepository.findById(transaction.getTransactionId())).thenReturn(
+        Optional.of(transaction));
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> transactionService.updateBuyerPurchase(
+            transaction.getTransactionId(), NOT_RECEIVED, token));
+    // then
+    verify(transactionRepository, never()).save(any());
+    assertEquals(INVALID_STATUS, e.getErrorCode());
+  }
+
+  @Test
+  void getSellerPurchaseList_Success() {
+    // given
+    String token = "token";
+    Pageable pageable = Pageable.ofSize(10);
+
+    Transaction transaction = Transaction.builder()
+        .transactionId(1L)
+        .member(member)
+        .roaster(roaster)
+        .paymentStatus(PAID)
+        .items(
+            List.of(
+                Item.builder()
+                    .beanId(cart.getBean().getId())
+                    .quantity(cart.getQuantity())
+                    .price(cart.getPriceAtAdded())
+                    .build(),
+                Item.builder()
+                    .beanId(cart2.getBean().getId())
+                    .quantity(cart2.getQuantity())
+                    .price(cart2.getPriceAtAdded())
+                    .build()
+            )).build();
+
+    Page<Transaction> transactionPage = new PageImpl<>(List.of(transaction));
+    when(jwtProvider.getMemberFromEmail(token)).thenReturn(member2);
+    when(transactionRepository.findByRoasterId(roaster.getId(), pageable)).thenReturn(
+        transactionPage);
+    // when
+    Page<TransactionSellerListDto> transactionSellerListDtoPage = transactionService.getSellerPurchaseList(
+        pageable, token);
+    // then
+    assertNotNull(transactionSellerListDtoPage);
+    assertEquals(1, transactionSellerListDtoPage.getTotalElements());
+  }
+
+  @Test
+  void getSellerPurchaseList_Success_EmptyList() {
+    // given
+    String token = "token";
+    Pageable pageable = Pageable.ofSize(10);
+
+    Page<Transaction> transactionPage = new PageImpl<>(List.of());
+    when(jwtProvider.getMemberFromEmail(token)).thenReturn(member2);
+    when(transactionRepository.findByRoasterId(roaster.getId(), pageable)).thenReturn(
+        transactionPage);
+    // when
+    Page<TransactionSellerListDto> transactionSellerListDtoPage = transactionService.getSellerPurchaseList(
+        pageable, token);
+    // then
+    assertNotNull(transactionSellerListDtoPage);
+    assertTrue(transactionSellerListDtoPage.isEmpty());
+  }
+
+  @Test
+  void getSellerPurchaseList_Failure_NotPermission() {
+    // given
+    String token = "token";
+    Pageable pageable = Pageable.ofSize(10);
+    member2.setRole(BUYER);
+
+    when(jwtProvider.getMemberFromEmail(token)).thenReturn(member2);
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> transactionService.getSellerPurchaseList(
+            pageable, token));
+    // then
+    assertEquals(NOT_PERMISSION, e.getErrorCode());
+  }
+
+  @Test
+  void updateSellerPurchaseList_Success_OrderConfirmed() {
+    // given
+    String token = "token";
+
+    Transaction transaction = Transaction.builder()
+        .transactionId(1L)
+        .member(member)
+        .roaster(roaster)
+        .paymentStatus(PAID)
+        .items(
+            List.of(
+                Item.builder()
+                    .beanId(cart.getBean().getId())
+                    .quantity(cart.getQuantity())
+                    .price(cart.getPriceAtAdded())
+                    .build(),
+                Item.builder()
+                    .beanId(cart2.getBean().getId())
+                    .quantity(cart2.getQuantity())
+                    .price(cart2.getPriceAtAdded())
+                    .build()
+            )).build();
+
+    when(jwtProvider.getMemberFromEmail(token)).thenReturn(member2);
+    when(transactionRepository.findById(transaction.getTransactionId())).thenReturn(
+        Optional.of(transaction));
+    // when
+    transactionService.updateSellerPurchase(transaction.getTransactionId(), ORDER_CONFIRMED, token);
+    // then
+    verify(transactionRepository).save(any());
+    assertEquals(ORDER_CONFIRMED, transaction.getPaymentStatus());
+  }
+
+  @Test
+  void updateSellerPurchaseList_Success_Exchanged() {
+    // given
+    String token = "token";
+
+    Transaction transaction = Transaction.builder()
+        .transactionId(1L)
+        .member(member)
+        .roaster(roaster)
+        .paymentStatus(EXCHANGE_REQUEST)
+        .items(
+            List.of(
+                Item.builder()
+                    .beanId(cart.getBean().getId())
+                    .quantity(cart.getQuantity())
+                    .price(cart.getPriceAtAdded())
+                    .build(),
+                Item.builder()
+                    .beanId(cart2.getBean().getId())
+                    .quantity(cart2.getQuantity())
+                    .price(cart2.getPriceAtAdded())
+                    .build()
+            )).build();
+
+    when(jwtProvider.getMemberFromEmail(token)).thenReturn(member2);
+    when(transactionRepository.findById(transaction.getTransactionId())).thenReturn(
+        Optional.of(transaction));
+    // when
+    transactionService.updateSellerPurchase(transaction.getTransactionId(), EXCHANGED, token);
+    // then
+    verify(transactionRepository).save(any());
+    assertEquals(EXCHANGED, transaction.getPaymentStatus());
+  }
+
+  @Test
+  void updateSellerPurchaseList_Failure_NotPermission_NotSeller() {
+    // given
+    String token = "token";
+    member2.setRole(BUYER);
+
+    Transaction transaction = Transaction.builder()
+        .transactionId(1L)
+        .member(member)
+        .roaster(roaster)
+        .paymentStatus(EXCHANGE_REQUEST)
+        .items(
+            List.of(
+                Item.builder()
+                    .beanId(cart.getBean().getId())
+                    .quantity(cart.getQuantity())
+                    .price(cart.getPriceAtAdded())
+                    .build(),
+                Item.builder()
+                    .beanId(cart2.getBean().getId())
+                    .quantity(cart2.getQuantity())
+                    .price(cart2.getPriceAtAdded())
+                    .build()
+            )).build();
+
+    when(jwtProvider.getMemberFromEmail(token)).thenReturn(member2);
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> transactionService.updateSellerPurchase(
+            transaction.getTransactionId(), EXCHANGED, token));
+    // then
+    verify(transactionRepository, never()).save(any());
+    assertEquals(NOT_PERMISSION, e.getErrorCode());
+  }
+
+  @Test
+  void updateSellerPurchaseList_Failure_NotPerMission_NotSame() {
+    // given
+    String token = "token";
+    Member member3 = new Member();
+    member3.setId(3L);
+
+    Transaction transaction = Transaction.builder()
+        .transactionId(1L)
+        .member(member)
+        .roaster(roaster)
+        .paymentStatus(EXCHANGE_REQUEST)
+        .items(
+            List.of(
+                Item.builder()
+                    .beanId(cart.getBean().getId())
+                    .quantity(cart.getQuantity())
+                    .price(cart.getPriceAtAdded())
+                    .build(),
+                Item.builder()
+                    .beanId(cart2.getBean().getId())
+                    .quantity(cart2.getQuantity())
+                    .price(cart2.getPriceAtAdded())
+                    .build()
+            )).build();
+
+    when(jwtProvider.getMemberFromEmail(token)).thenReturn(member3);
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> transactionService.updateSellerPurchase(
+            transaction.getTransactionId(), EXCHANGED, token));
+    // then
+    verify(transactionRepository, never()).save(any());
+    assertEquals(NOT_PERMISSION, e.getErrorCode());
+  }
+
+  @Test
+  void updateSellerPurchaseList_Failure_InvalidStatus() {
+    // given
+    String token = "token";
+
+    Transaction transaction = Transaction.builder()
+        .transactionId(1L)
+        .member(member)
+        .roaster(roaster)
+        .paymentStatus(EXCHANGE_REQUEST)
+        .items(
+            List.of(
+                Item.builder()
+                    .beanId(cart.getBean().getId())
+                    .quantity(cart.getQuantity())
+                    .price(cart.getPriceAtAdded())
+                    .build(),
+                Item.builder()
+                    .beanId(cart2.getBean().getId())
+                    .quantity(cart2.getQuantity())
+                    .price(cart2.getPriceAtAdded())
+                    .build()
+            )).build();
+
+    when(jwtProvider.getMemberFromEmail(token)).thenReturn(member2);
+    when(transactionRepository.findById(transaction.getTransactionId())).thenReturn(
+        Optional.of(transaction));
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> transactionService.updateSellerPurchase(transaction.getTransactionId(), DELIVERED,
+            token));
+    // then
+    verify(transactionRepository, never()).save(any());
+    assertEquals(INVALID_STATUS, e.getErrorCode());
+  }
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

- 이전 작업으로 회원관련 로직, 원두 레시피 등록 및 레시피 조회 로직 구현 완료
- 로스터(판매자) 가 등록한 원두의 정보에서 장바구니에 담는 로직 구현하기
- 결제 시템을 연동하여 결제시 결과를 처리하고 구매목록, 판매목록 등 결제관련 서비스 구현하기

**ISSUE**
- CustomException 이 발생할 경우. 추가 메세지가 들어가야 하는 경우 발생
-> 필드에서 추가 메세지를 입력할 경우를 대비해서 생성자 추가

**TO-BE**

[공통]
- cart 테이블은 member 테이블과 1 : N 관계로 설정
- transaction 테이블은 member 테이블과 1 : N 관계로 설정
- transaction 테이블은 bean 테이블과 1 : N 관계로 설정
- Port One API 를 활용하여 결제 요청등을 보내면 결제 결과를 처리하는 결제 서비스 구현

[장바구니 등록]
- 장바구니에 상품 등록 시 BeanId 당 최소 1개 ~ 최대 100 개 까지 구매 가능하게끔 세팅
- 기존 장바구니에 동일한 BeanId 가 있을 때, 수량을 업데이트

[장바구니 조회]
- 장바구니 조회시 token 을 확인하여 회원을 조회한 후 장바구니 목록을 반환
- 장바구니가 비어있는 경우 빈 배열 반환

[장바구니 수정]
- 장바구니 수정시 token 을 확인하여 장바구니 소유자 인 경우 수정이 가능
- 수정된 정보가 null 이 아닌경우에만 수정이 진행
- 상품수량을 null 값으로 허용하기 위해 입력받는 dto는 Integer 로 설정

[장바구니 삭제]
- 장바구니 삭제시 token 을 확인하여 장바구니 소유자 인 경우 삭제가 가능

[주문서 생성]
- 클라이언트 측에서 Port One 쪽으로 결제 진행 요청을 보내면 Port One 에서 생성된 imp_uid 값을 비교하기 위해 서버측으로 merchant_uid 값과 주문 정보를 transaction 테이블에 저장
- 주문서 생성 과정에서 token 을 확인하여 회원을 조회
- 주문서 상의 원두 정보 중 원두가 없는 경우, 판매상태가 변경된 경우(불가능), 가격이 변동되었을 경우 적절한 예외처리를 통해 주문서 생성 취소
- 주문서는 동일한 로스터의 원두만 구매 가능
- 모든 예외를 통과한 주문서는 결제상태를 준비 상태로 지정한 후 저장

[결제 검증]
- Port One 측에서 생성된 imp_uid 값을 비교하여 DB 에 저장된 주문서와 일치하는지 확인
- 주문서에 있는 총 금액을 확인하여 실제 결제 금액과 동일하지 않으면 예외처리(JS 를 조작하여 금액을 수정하는 등 취약부분 보완)
- 금액 검증 후 transaction 테이블에 총 금액과 판매상태를 업데이트 한 후 결제 완료 처리
- 결제가 완료된 상품은 장바구니에서 제거

[결제 취소]
- 클라이언트 측에서 Port One 으로 결제 취소를 요청하면 서버에서 취소요청한 정보와 비교를 하여 일치하면 취소 진행
- 취소요청 정볼르 확인하여 취소요청이 아닌 경우, 주문서가 없는 경우, 취소 요청이 없는 경우 를 확인하여 각각 예외처리
- 취소가 완료되면 주문서 상의 상태는 취소상태로 업데이트 한 후 transaction 테이블에 저장

[구매목록 조회]
- 사용자의 token 을 사용하여 사용자의 구매목록을 조회
- 구매목록은 Paging 처리

[구매상태 변경 - Buyer]
- Buyer 인 사용자는 취소요청, 반품요청, 교환요청, 미수령 등 판매자에게 요청을 보낼 수 가 있음
- token 을 확인하여 사용자를 확인하고 주문서의 주인인 사용자만 상태 변경 가능
- 결제 취소요청은 결제상태가 결제완료, 주문확인 상태에서 결제 취소 요청을 보낼 수 있음
- 반품요청, 교환요청, 미수령, 구매확정은 배송이 완료된 상태에서만 상태 변경 가능

[판매목록 조회]
- 사용자의 token 을 사용하여 사용자의 판매목록을 조회
- 사용자가 "SELLER" 가 아니면 접근 불가
- transaction 테이블의 Roaster 객체의 ID 를 추출해 판매목록 조회
- 판매목록은 Paging 처리

[판매상태 변경 - Seller]
- token 을 활용하여 사용자를 확인하고, 그 사용자가 "SELLER" 가 아니면 접근 불가
- transaction 의 판매자 정보와 변경하려는 판매자와 다를 경우 접근 불가
- 현재 주문서 유형이 결제 완료 시 주문확인 으로 변경 가능
- 현재 주문확인 상태 시 배송준비중 으로 변경 가능
- 현재 배송준비중 상태 시 배송중 상태로 변경 가능
- 현재 배송중 상태 시 배송 완료 상태로 변경 가능
- 현재 반품 요청 상태 시 반품완료 상태로 변경 가능
- 현재 교환 요청 상태 시 교환완료 상태로 변경 가능

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드

[장바구니 등록 테스트]
- 장바구니에 원두를 성공적으로 추가할 수 있는지 확인
- 장바구니에 새로운 원두를 추가할 때 성공적으로 추가할 수 있는지 확인
- 이미 존재하는 원두에 대해 동일한 원두를 추가할 때 총 수량이 합산되는지 검증
- 원두가 존재하지 않을 때 예외가 발생하는지 검증
- 불가능한 구매 상태일 경우 예외가 발생하는지 검증
- 장바구니에 추가할 원두의 총 수량이 100개가 넘는 경우 예외가 발생하는지 검증
- 이미 존재하는 원두에 대해 수량을 증가시킬 때 총 수량이 100개가 넘는 경우 예외가 발생하는지 검증

[장바구니 조회 테스트]
- 장바구니에 원두가 성공적으로 추가된 경우, 각 원두 정보가 알맞게 조회가 되는지 확인
- 장바구니가 비어있는 경우, 빈 배열을 반환하고 있는지 확인

[장바구니 수정 테스트]
- 장바구니에 있는 원두의 상품수량과 요청사항을 수정할 경우 성공적으로 수정할 수 있는지 확인
- 장바구니에 있는 원두의 요청사항만 수정할 경우 성공적으로 수정할 수 있는지 확인
- 장바구니에 있는 원두의 삼품수량만 수정할 경우 성공적으로 수정할 수 있는지 확인
- 장바구니 수정 시도할 때, 해당 상품이 없는 경우 예외가 발생하는지 검증

[장바구니 삭제 테스트]
- 장바구니에 원두가 등록되어 있는 경우, 성공적으로 삭제할 수 있는지 확인
- 삭제하려는 장바구니가 존재하지 않을 경우 예외가 발생하는지 검증
- 권한이 없는 사용자가 장바구니를 삭제를 시도할 경우 예외가 발생하는지 검증

[주문서 생성 테스트]
- 장바구니에 제품이 정상적으로 등록되어있는 경우, 성공적으로 주문서가 생성이 되는지 확인
- 주문서 생성 시 특정 원두가 존재하지 않을 경우 예외가 발생하는 지 검증
- 장바구니에 제품을 담은 상태에서 해당 원두의 판매상태가 "IMPOSSIBLE" 로 변경 되었을때 예외가 발생하는 지 검증
- 장바구니에 제품을 담은 상태에서 해당 원두의 가격이 변경 되었을때 예외가 발생하는 지 검증

[주문서 검증 테스트]
- Port One 측으로부터 정상적인 상태코드("paid") 를 넘겨받았을 때, DB에 저장된 값이랑 일치하는지 확인
- 성공적으로 검증이 되었을때 장바구니 테이블에서 데이터가 정상적으로 삭제되는지 검증
- Port One 측에서 "paid" 상태 코드를 넘겨주지 않았을때, 예외가 발생하는 지 검증
- 주문서 검증 시 DB 에 저장된 주문서가 없을 때, 예외가 발생하는 지 검증
- 실 결제 금액과 DB 에 저장된 결제 금액이 다를 시, 예외가 발생하는 지 검증
- 그 외의 예외 상황에서 적절한 예외가 발생하는 지 검증

[결제 취소 테스트]
- 정상적으로 결제가 취소가 되는지 검증
- Port One 에서 제공해 준 정보를 비교하여 DB에 저장된 주문서가 없을 시 예외가 발생하는 지 검증
- DB 에 저장되있는 주문서의 상태가 "CANCEL_REQUEST" 가 아닌 경우 예외 발생 검증
- Port One 에서 결제취소를 진행하였으나, 반환된 상태 코드가 여전히 "paid" 인 경우 예외가 발생하는 지 검증

[구매목록 조회]
- 사용자의 token 을 활용하여 사용자가 구매 내역이 조회가 되는지 확인
- 사용자의 구매내역이 없는 경우 빈 배열을 반환하는지 검증

[구매상태 변경 - Buyer]
- 주문서를 통해 취소 요청을 할 수 있는지 확인
- 배송완료된 상태에서 구매확정으로 변경할 수 있는지 확인
- 주문서를 소유하고 있는 사용자가 아닌 다른 사용자가 변경 시도할 경우 예외가 발생하는 지 검증
- 배송 시작 전에 미수령 상태로 변경 시도 시 예외가 발생하는 지 검증

[판매목록 조회]
- 판매자의 token 을 활용하여 판매자의 판매 목록이 조회가 되는지 확인
- 판매목록이 없는 경우 빈 배열을 반환하는지 검증
- 판매자가 아닌 사용자가 판매목록을 조회 시도 시 예외가 발생하는 지 검증

[판매상태 변경 - Seller]
- 주문이 들어왔을 경우(구매자가 결제를 한 경우) 판매 상태를 주문확인 상태로 변경할 수 있는지 확인
- 교환 요청이 들어온 주문서에 교환완료 상태로 변경이 가능한지 확인
- 판매자가 아닌 사용자가 판매상태를 변경 시도 시 예외가 발생하는 지 검증
- 동일한 판매자가 아닌 사용자가 판매상태를 변경 시도 시 예외가 발생하는 지 검증
- 주문서의 상태가 교환요청 일 경우, 배송완료 로 변경 시도 시 예외가 발생하는 지 검증

- [ ] API 테스트

- 각 상황에 대해 정상적으로 API 가 정상 작동 하는지, 여러 상황에 대해서 예외처리가 올바르게 작동 하는 지 확인 완료
- 여러 판매자가 등록한 원두의 경우 하나의 판매자에게서만 묶음으로 주문서를 생성할 수 있는지 확인 하고, 일반 사용자가 여러 로스터에게 각각 주문서를 생성한 경우, 판매자 별로 본인의 판매 상품만 보이는지 확인 완료

- 일반 사용자가 두 명의 로스터에게 각각 3개씩 원두를 구매한 경우 - 주문서 2개 생성
```json
{
  "data": [
    {
      "transactionId": 1,
      "items": [
        {
          "beanId": 1,
          "quantity": 1,
          "price": 1000
        },
        {
          "beanId": 2,
          "quantity": 1,
          "price": 1000
        },
        {
          "beanId": 3,
          "quantity": 1,
          "price": 1000
        }
      ],
      "totalPrice": null,
      "paymentStatus": "READY",
      "paymentMethod": "CARD",
      "createdAt": "2024-11-05T08:49:31.676749",
      "updatedAt": null
    },
    {
      "transactionId": 2,
      "items": [
        {
          "beanId": 4,
          "quantity": 1,
          "price": 1000
        },
        {
          "beanId": 5,
          "quantity": 1,
          "price": 1000
        },
        {
          "beanId": 6,
          "quantity": 1,
          "price": 1000
        }
      ],
      "totalPrice": null,
      "paymentStatus": "READY",
      "paymentMethod": "CARD",
      "createdAt": "2024-11-05T08:49:39.948021",
      "updatedAt": null
    }
  ],
  "totalElements": 2,
  "totalPages": 1
}
```

- 1번 로스터 판매목록 조회 화면
```json
{
  "data": [
    {
      "transactionId": 1,
      "buyerId": 3,
      "buyerAddress": "testAddress",
      "items": [
        {
          "beanId": 1,
          "quantity": 1,
          "price": 1000
        },
        {
          "beanId": 2,
          "quantity": 1,
          "price": 1000
        },
        {
          "beanId": 3,
          "quantity": 1,
          "price": 1000
        }
      ],
      "totalPrice": null,
      "paymentStatus": "READY",
      "paymentMethod": "CARD",
      "createdAt": "2024-11-05T08:49:31.676749",
      "updatedAt": null
    }
  ],
  "totalElements": 1,
  "totalPages": 1
}
```

- 2번 로스터 판매목록 조회 화면
```json
{
  "data": [
    {
      "transactionId": 2,
      "buyerId": 3,
      "buyerAddress": "testAddress",
      "items": [
        {
          "beanId": 4,
          "quantity": 1,
          "price": 1000
        },
        {
          "beanId": 5,
          "quantity": 1,
          "price": 1000
        },
        {
          "beanId": 6,
          "quantity": 1,
          "price": 1000
        }
      ],
      "totalPrice": null,
      "paymentStatus": "READY",
      "paymentMethod": "CARD",
      "createdAt": "2024-11-05T08:49:39.948021",
      "updatedAt": null
    }
  ],
  "totalElements": 1,
  "totalPages": 1
}
```