### PR TITLE
feat : [004 - Review, Favorite API]

### DIFF
--- a/src/main/java/com/coffee/coffeeserviceproject/bean/service/BeanService.java
+++ b/src/main/java/com/coffee/coffeeserviceproject/bean/service/BeanService.java
@@ -256,6 +256,7 @@ public class BeanService {
   }
 
   @Async
+  @Transactional
   public void deleteDataAsync(Long beanId) {
 
     searchRepository.deleteById(beanId);

--- a/src/main/java/com/coffee/coffeeserviceproject/bean/service/BeanService.java
+++ b/src/main/java/com/coffee/coffeeserviceproject/bean/service/BeanService.java
@@ -17,11 +17,15 @@ import com.coffee.coffeeserviceproject.common.exception.CustomException;
 import com.coffee.coffeeserviceproject.configuration.JwtProvider;
 import com.coffee.coffeeserviceproject.elasticsearch.document.SearchBeanList;
 import com.coffee.coffeeserviceproject.elasticsearch.repository.SearchRepository;
+import com.coffee.coffeeserviceproject.favorite.repository.FavoriteRepository;
 import com.coffee.coffeeserviceproject.member.entity.Member;
 import com.coffee.coffeeserviceproject.member.type.RoleType;
+import com.coffee.coffeeserviceproject.review.repository.ReviewRepository;
+import com.coffee.coffeeserviceproject.review.service.ReviewService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -34,6 +38,12 @@ public class BeanService {
   private final JwtProvider jwtProvider;
 
   private final SearchRepository searchRepository;
+
+  private final ReviewRepository reviewRepository;
+
+  private final ReviewService reviewService;
+
+  private final FavoriteRepository favoriteRepository;
 
   @Transactional
   public void addBean(BeanDto beanDto, String token) {
@@ -231,7 +241,7 @@ public class BeanService {
     Bean bean = beanRepository.findById(id)
         .orElseThrow(() -> new CustomException(NOT_FOUND_BEAN));
 
-    SearchBeanList searchBeanList = searchRepository.findById(bean.getId())
+    searchRepository.findById(id)
         .orElseThrow(() -> new CustomException(NOT_FOUND_BEAN));
 
     Member member = jwtProvider.getMemberFromEmail(token);
@@ -240,7 +250,17 @@ public class BeanService {
       throw new CustomException(NOT_PERMISSION);
     }
 
-    beanRepository.delete(bean);
-    searchRepository.delete(searchBeanList);
+    reviewService.updateAverageScore(id);
+
+    deleteDataAsync(id);
+  }
+
+  @Async
+  public void deleteDataAsync(Long beanId) {
+
+    searchRepository.deleteById(beanId);
+    favoriteRepository.deleteAllByBeanId(beanId);
+    reviewRepository.deleteAllByBeanId(beanId);
+    beanRepository.deleteById(beanId);
   }
 }

--- a/src/main/java/com/coffee/coffeeserviceproject/common/type/ErrorCode.java
+++ b/src/main/java/com/coffee/coffeeserviceproject/common/type/ErrorCode.java
@@ -31,7 +31,11 @@ public enum ErrorCode {
   INVALID_STATUS("INVALID_STATUS", "잘못된 요청입니다."),
   FAILURE_CANCEL("FAILURE_CANCEL", "결제 취소에 실패하였습니다."),
   SAME_ROASTER("SAME_ROASTER", "동일한 로스터의 원두만 주문이 가능합니다."),
-  NOT_FOUND_ROASTER("NOT_FOUND_ROASTER", "로스터를 찾지 못했습니다.")
+  NOT_FOUND_ROASTER("NOT_FOUND_ROASTER", "로스터를 찾지 못했습니다."),
+  SCORE_MULTIPLE_05("SCORE_MULTIPLE_0.5", "점수는 0.5 의 배수여야 합니다."),
+  NOT_FOUND_REVIEW("NOT_FOUND_REVIEW", "리뷰를 찾지 못했습니다."),
+  NOT_FOUND_FAVORITE("NOT_FOUND_FAVORITE", "즐겨찾기를 찾지 못했습니다."),
+  ALREADY_FAVORITE_BEAN("ALREADY_FAVORITE_BEAN", "이미 즐겨찾기가 되어있습니다.")
   ;
 
   private final String code;

--- a/src/main/java/com/coffee/coffeeserviceproject/favorite/controller/FavoriteController.java
+++ b/src/main/java/com/coffee/coffeeserviceproject/favorite/controller/FavoriteController.java
@@ -1,0 +1,58 @@
+package com.coffee.coffeeserviceproject.favorite.controller;
+
+import com.coffee.coffeeserviceproject.common.model.ListResponseDto;
+import com.coffee.coffeeserviceproject.favorite.dto.FavoriteDto;
+import com.coffee.coffeeserviceproject.favorite.service.FavoriteService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/favorites")
+public class FavoriteController {
+
+  private final FavoriteService favoriteService;
+
+  @PostMapping("/beans/{beanId}")
+  public ResponseEntity<Void> addFavorite(@PathVariable Long beanId,
+      @RequestHeader("AUTH-TOKEN") String token) {
+
+    favoriteService.addFavorite(beanId, token);
+
+    return ResponseEntity.noContent().build();
+  }
+
+  @GetMapping("/members/me")
+  public ResponseEntity<ListResponseDto<List<FavoriteDto>>> getFavoriteList(
+      @RequestHeader("AUTH-TOKEN") String token,
+      Pageable pageable) {
+
+    Page<FavoriteDto> favoritePage = favoriteService.getFavoriteList(token, pageable);
+
+    ListResponseDto<List<FavoriteDto>> responseDto = new ListResponseDto<>(
+        favoritePage.getContent(),
+        favoritePage.getTotalElements(),
+        favoritePage.getTotalPages());
+
+    return ResponseEntity.ok(responseDto);
+  }
+
+  @DeleteMapping("/{id}")
+  public ResponseEntity<Void> deleteFavorite(@PathVariable Long id,
+      @RequestHeader("AUTH-TOKEN") String token) {
+
+    favoriteService.deleteFavorite(id, token);
+
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/src/main/java/com/coffee/coffeeserviceproject/favorite/dto/FavoriteDto.java
+++ b/src/main/java/com/coffee/coffeeserviceproject/favorite/dto/FavoriteDto.java
@@ -1,0 +1,25 @@
+package com.coffee.coffeeserviceproject.favorite.dto;
+
+import com.coffee.coffeeserviceproject.bean.entity.Bean;
+import com.coffee.coffeeserviceproject.favorite.entity.Favorite;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class FavoriteDto {
+
+  private String beanName;
+
+  private String roasterName;
+
+  public static FavoriteDto fromEntity(Favorite favorite) {
+
+    Bean bean = favorite.getBean();
+
+    return FavoriteDto.builder()
+        .beanName(bean.getBeanName())
+        .roasterName(bean.getRoasterName() != null ? bean.getRoasterName() : null)
+        .build();
+  }
+}

--- a/src/main/java/com/coffee/coffeeserviceproject/favorite/entity/Favorite.java
+++ b/src/main/java/com/coffee/coffeeserviceproject/favorite/entity/Favorite.java
@@ -32,9 +32,14 @@ public class Favorite {
   @JoinColumn(name = "bean_id", nullable = false)
   private Bean bean;
 
-  public static Favorite from(Member member, Bean bean) {
-    return Favorite.builder()
-        .member(member)
-        .bean(bean).build();
+  public Favorite(Member member, Bean bean) {
+
+    this.member = member;
+    this.bean = bean;
+  }
+
+  public static Favorite of(Member member, Bean bean) {
+
+    return new Favorite(member, bean);
   }
 }

--- a/src/main/java/com/coffee/coffeeserviceproject/favorite/entity/Favorite.java
+++ b/src/main/java/com/coffee/coffeeserviceproject/favorite/entity/Favorite.java
@@ -1,0 +1,40 @@
+package com.coffee.coffeeserviceproject.favorite.entity;
+
+import com.coffee.coffeeserviceproject.bean.entity.Bean;
+import com.coffee.coffeeserviceproject.member.entity.Member;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Favorite {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne
+  @JoinColumn(name = "member_id", nullable = false)
+  private Member member;
+
+  @ManyToOne
+  @JoinColumn(name = "bean_id", nullable = false)
+  private Bean bean;
+
+  public static Favorite from(Member member, Bean bean) {
+    return Favorite.builder()
+        .member(member)
+        .bean(bean).build();
+  }
+}

--- a/src/main/java/com/coffee/coffeeserviceproject/favorite/repository/FavoriteRepository.java
+++ b/src/main/java/com/coffee/coffeeserviceproject/favorite/repository/FavoriteRepository.java
@@ -7,13 +7,19 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
 
   Page<Favorite> findAllByMemberId(long memberId, Pageable pageable);
 
+  @Modifying
+  @Query(value = "delete from favorite where bean_id = :id", nativeQuery = true)
   void deleteAllByBeanId(Long id);
 
+  @Modifying
+  @Query(value = "delete from favorite where member_id = :memberId", nativeQuery = true)
   void deleteAllByMemberId(Long memberId);
 
   Optional<Favorite> findByMemberAndBean(Member member, Bean bean);

--- a/src/main/java/com/coffee/coffeeserviceproject/favorite/repository/FavoriteRepository.java
+++ b/src/main/java/com/coffee/coffeeserviceproject/favorite/repository/FavoriteRepository.java
@@ -1,0 +1,20 @@
+package com.coffee.coffeeserviceproject.favorite.repository;
+
+import com.coffee.coffeeserviceproject.bean.entity.Bean;
+import com.coffee.coffeeserviceproject.favorite.entity.Favorite;
+import com.coffee.coffeeserviceproject.member.entity.Member;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
+
+  Page<Favorite> findAllByMemberId(long memberId, Pageable pageable);
+
+  void deleteAllByBeanId(Long id);
+
+  void deleteAllByMemberId(Long memberId);
+
+  Optional<Favorite> findByMemberAndBean(Member member, Bean bean);
+}

--- a/src/main/java/com/coffee/coffeeserviceproject/favorite/service/FavoriteService.java
+++ b/src/main/java/com/coffee/coffeeserviceproject/favorite/service/FavoriteService.java
@@ -42,7 +42,7 @@ public class FavoriteService {
           throw new CustomException(ALREADY_FAVORITE_BEAN);
         });
 
-    Favorite favorite = Favorite.from(member, bean);
+    Favorite favorite = Favorite.of(member, bean);
 
     favoriteRepository.save(favorite);
   }

--- a/src/main/java/com/coffee/coffeeserviceproject/favorite/service/FavoriteService.java
+++ b/src/main/java/com/coffee/coffeeserviceproject/favorite/service/FavoriteService.java
@@ -1,0 +1,78 @@
+package com.coffee.coffeeserviceproject.favorite.service;
+
+import static com.coffee.coffeeserviceproject.common.type.ErrorCode.ALREADY_FAVORITE_BEAN;
+import static com.coffee.coffeeserviceproject.common.type.ErrorCode.NOT_FOUND_BEAN;
+import static com.coffee.coffeeserviceproject.common.type.ErrorCode.NOT_FOUND_FAVORITE;
+import static com.coffee.coffeeserviceproject.common.type.ErrorCode.NOT_PERMISSION;
+
+import com.coffee.coffeeserviceproject.bean.entity.Bean;
+import com.coffee.coffeeserviceproject.bean.repository.BeanRepository;
+import com.coffee.coffeeserviceproject.common.exception.CustomException;
+import com.coffee.coffeeserviceproject.configuration.JwtProvider;
+import com.coffee.coffeeserviceproject.favorite.dto.FavoriteDto;
+import com.coffee.coffeeserviceproject.favorite.entity.Favorite;
+import com.coffee.coffeeserviceproject.favorite.repository.FavoriteRepository;
+import com.coffee.coffeeserviceproject.member.entity.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class FavoriteService {
+
+  private final FavoriteRepository favoriteRepository;
+
+  private final JwtProvider jwtProvider;
+
+  private final BeanRepository beanRepository;
+
+  @Transactional
+  public void addFavorite(Long beanId, String token) {
+
+    Member member = jwtProvider.getMemberFromEmail(token);
+
+    Bean bean = beanRepository.findById(beanId)
+        .orElseThrow(() -> new CustomException(NOT_FOUND_BEAN));
+
+    favoriteRepository.findByMemberAndBean(member, bean)
+        .ifPresent(existsFavorite -> {
+          throw new CustomException(ALREADY_FAVORITE_BEAN);
+        });
+
+    Favorite favorite = Favorite.from(member, bean);
+
+    favoriteRepository.save(favorite);
+  }
+
+  @Transactional(readOnly = true)
+  public Page<FavoriteDto> getFavoriteList(String token, Pageable pageable) {
+
+    Member member = jwtProvider.getMemberFromEmail(token);
+
+    Long memberId = member.getId();
+
+    Page<Favorite> favoritePage = favoriteRepository.findAllByMemberId(memberId, pageable);
+
+    return favoritePage.map(FavoriteDto::fromEntity);
+  }
+
+  @Transactional
+  public void deleteFavorite(Long id, String token) {
+
+    Member member = jwtProvider.getMemberFromEmail(token);
+
+    Long memberId = member.getId();
+
+    Favorite favorite = favoriteRepository.findById(id)
+        .orElseThrow(() -> new CustomException(NOT_FOUND_FAVORITE));
+
+    if (!memberId.equals(favorite.getMember().getId())) {
+      throw new CustomException(NOT_PERMISSION);
+    }
+
+    favoriteRepository.delete(favorite);
+  }
+}

--- a/src/main/java/com/coffee/coffeeserviceproject/member/service/MemberService.java
+++ b/src/main/java/com/coffee/coffeeserviceproject/member/service/MemberService.java
@@ -188,6 +188,7 @@ public class MemberService {
   }
 
   @Async
+  @Transactional
   public void deleteBeanDataAsync(List<Long> beanIds) {
 
     final int BATCH_SIZE = 100;
@@ -206,6 +207,7 @@ public class MemberService {
   }
 
   @Async
+  @Transactional
   public void deleteMemberDataAsync(Long memberId) {
 
     reviewRepository.deleteAllByMemberId(memberId);

--- a/src/main/java/com/coffee/coffeeserviceproject/member/service/MemberService.java
+++ b/src/main/java/com/coffee/coffeeserviceproject/member/service/MemberService.java
@@ -9,7 +9,9 @@ import static com.coffee.coffeeserviceproject.member.type.RoleType.SELLER;
 import com.coffee.coffeeserviceproject.bean.entity.Bean;
 import com.coffee.coffeeserviceproject.bean.repository.BeanRepository;
 import com.coffee.coffeeserviceproject.common.exception.CustomException;
+import com.coffee.coffeeserviceproject.configuration.JwtProvider;
 import com.coffee.coffeeserviceproject.elasticsearch.repository.SearchRepository;
+import com.coffee.coffeeserviceproject.favorite.repository.FavoriteRepository;
 import com.coffee.coffeeserviceproject.member.dto.MemberDeleteDto;
 import com.coffee.coffeeserviceproject.member.dto.MemberDto;
 import com.coffee.coffeeserviceproject.member.dto.MemberUpdateDto;
@@ -18,12 +20,15 @@ import com.coffee.coffeeserviceproject.member.entity.Member;
 import com.coffee.coffeeserviceproject.member.entity.Roaster;
 import com.coffee.coffeeserviceproject.member.repository.MemberRepository;
 import com.coffee.coffeeserviceproject.member.repository.RoasterRepository;
-import com.coffee.coffeeserviceproject.configuration.JwtProvider;
+import com.coffee.coffeeserviceproject.review.repository.ReviewRepository;
+import com.coffee.coffeeserviceproject.review.service.ReviewService;
 import com.coffee.coffeeserviceproject.util.PasswordUtil;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -41,6 +46,13 @@ public class MemberService {
 
   private final RoasterRepository roasterRepository;
 
+  private final ReviewRepository reviewRepository;
+
+  private final ReviewService reviewService;
+
+  private final FavoriteRepository favoriteRepository;
+
+  @Transactional
   public void addMember(MemberDto memberDto) {
 
     if (memberRepository.findByEmail(memberDto.getEmail()).isPresent()) {
@@ -63,6 +75,7 @@ public class MemberService {
     mailService.sendEmail(memberDto.getEmail());
   }
 
+  @Transactional
   public String login(String email, String password) {
 
     Member member = memberRepository.findByEmail(email).orElse(null);
@@ -75,6 +88,7 @@ public class MemberService {
     return jwtProvider.generateToken(email);
   }
 
+  @Transactional(readOnly = true)
   public MemberDto getMember(String token) {
 
     Member member = jwtProvider.getMemberFromEmail(token);
@@ -103,6 +117,7 @@ public class MemberService {
     return memberDto;
   }
 
+  @Transactional
   public void updateMember(String token, MemberUpdateDto memberUpdateDto) {
 
     Member member = jwtProvider.getMemberFromEmail(token);
@@ -141,9 +156,12 @@ public class MemberService {
     }
   }
 
+  @Transactional
   public void deleteMember(String token, MemberDeleteDto memberDeleteDto) {
 
     Member member = jwtProvider.getMemberFromEmail(token);
+
+    Long memberId = member.getId();
 
     if (!PasswordUtil.matches(memberDeleteDto.getConfirmPassword(), member.getPassword())) {
       throw new CustomException(WRONG_PASSWORD);
@@ -156,13 +174,42 @@ public class MemberService {
     List<Bean> beanList = beanRepository.findAllByMemberId(member.getId());
 
     if (!beanList.isEmpty()) {
+
       beanRepository.deleteAll(beanList);
 
-      List<Long> searchBeanIds = beanList.stream().map(Bean::getId).collect(Collectors.toList());
+      List<Long> beanIds = beanList.stream()
+          .map(Bean::getId)
+          .collect(Collectors.toList());
 
-      searchRepository.deleteAllByBeanIdIn(searchBeanIds);
+      deleteBeanDataAsync(beanIds);
     }
 
-    memberRepository.delete(member);
+    deleteMemberDataAsync(memberId);
+  }
+
+  @Async
+  public void deleteBeanDataAsync(List<Long> beanIds) {
+
+    final int BATCH_SIZE = 100;
+
+    for (int i = 0; i < beanIds.size(); i+= BATCH_SIZE) {
+
+      List<Long> batchBeanIds = beanIds.subList(i, Math.min(i + BATCH_SIZE, beanIds.size()));
+
+      for (Long beanId : batchBeanIds) {
+
+        reviewService.updateAverageScore(beanId);
+      }
+
+      searchRepository.deleteAllByBeanIdIn(batchBeanIds);
+    }
+  }
+
+  @Async
+  public void deleteMemberDataAsync(Long memberId) {
+
+    reviewRepository.deleteAllByMemberId(memberId);
+    favoriteRepository.deleteAllByMemberId(memberId);
+    memberRepository.deleteById(memberId);
   }
 }

--- a/src/main/java/com/coffee/coffeeserviceproject/review/controller/ReviewController.java
+++ b/src/main/java/com/coffee/coffeeserviceproject/review/controller/ReviewController.java
@@ -1,0 +1,91 @@
+package com.coffee.coffeeserviceproject.review.controller;
+
+import com.coffee.coffeeserviceproject.common.model.ListResponseDto;
+import com.coffee.coffeeserviceproject.review.dto.ReviewRequestDto;
+import com.coffee.coffeeserviceproject.review.dto.ReviewResponseDto;
+import com.coffee.coffeeserviceproject.review.service.ReviewService;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/reviews")
+public class ReviewController {
+
+  private final ReviewService reviewService;
+
+  @PostMapping("/{beanId}")
+  public ResponseEntity<Void> addReview(@PathVariable Long beanId,
+      @RequestBody @Valid ReviewRequestDto reviewRequestDto,
+      @RequestHeader("AUTH-TOKEN") String token) {
+
+    reviewService.addReview(beanId, reviewRequestDto, token);
+
+    return ResponseEntity.noContent().build();
+  }
+
+  @GetMapping("/members/me")
+  public ResponseEntity<ListResponseDto<List<ReviewResponseDto>>> getMyReviewList(Pageable pageable,
+      @RequestHeader("AUTH-TOKEN") String token) {
+
+    Page<ReviewResponseDto> reviewResponseDtoPage = reviewService.getMyReviewList(pageable, token);
+
+    ListResponseDto<List<ReviewResponseDto>> responseDto = new ListResponseDto<>(
+        reviewResponseDtoPage.getContent(),
+        reviewResponseDtoPage.getTotalElements(),
+        reviewResponseDtoPage.getTotalPages());
+
+    return ResponseEntity.ok(responseDto);
+  }
+
+  @GetMapping("/beans/{beanId}")
+  public ResponseEntity<ListResponseDto<List<ReviewResponseDto>>> getBeanReviewList(
+      Pageable pageable,
+      @PathVariable("beanId") Long beanId) {
+
+    Page<ReviewResponseDto> reviewResponseDtoPage = reviewService.getBeanReviewList(pageable,
+        beanId);
+
+    ListResponseDto<List<ReviewResponseDto>> responseDto = new ListResponseDto<>(
+        reviewResponseDtoPage.getContent(),
+        reviewResponseDtoPage.getTotalElements(),
+        reviewResponseDtoPage.getTotalPages());
+
+    return ResponseEntity.ok(responseDto);
+  }
+
+  @PatchMapping("/{id}")
+  public ResponseEntity<Void> updateReview(@PathVariable("id") Long id,
+      @RequestHeader("AUTH-TOKEN") String token,
+      @RequestBody @Valid @NotBlank(message = "리뷰를 작성해 주세요.")
+      @Size(min = 10, message = "최소 10글자 이상 입력해 주세요.") String comment) {
+
+    reviewService.updateReview(id, token, comment);
+
+    return ResponseEntity.noContent().build();
+  }
+
+  @DeleteMapping("/{id}")
+  public ResponseEntity<Void> deleteReview(@PathVariable("id") Long id,
+      @RequestHeader("AUTH-TOKEN") String token) {
+
+    reviewService.deleteReview(id, token);
+
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/src/main/java/com/coffee/coffeeserviceproject/review/dto/ReviewRequestDto.java
+++ b/src/main/java/com/coffee/coffeeserviceproject/review/dto/ReviewRequestDto.java
@@ -1,0 +1,25 @@
+package com.coffee.coffeeserviceproject.review.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+public class ReviewRequestDto {
+
+  @NotNull(message = "별점을 등록해 주세요.")
+  @Min(value = 0, message = "최소 점수는 0.0 입니다.")
+  @Max(value = 5, message = "최대 점수는 5.0 입니다.")
+  private Double score;
+
+  @NotBlank(message = "리뷰를 작성해 주세요.")
+  @Size(min = 10, message = "최소 10글자 이상 입력해 주세요.")
+  private String comment;
+
+  public boolean isValidScore() {
+    return score % 0.5 == 0;
+  }
+}

--- a/src/main/java/com/coffee/coffeeserviceproject/review/dto/ReviewResponseDto.java
+++ b/src/main/java/com/coffee/coffeeserviceproject/review/dto/ReviewResponseDto.java
@@ -1,0 +1,46 @@
+package com.coffee.coffeeserviceproject.review.dto;
+
+import com.coffee.coffeeserviceproject.review.entity.Review;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class ReviewResponseDto {
+
+  private String memberName;
+
+  private String beanName;
+
+  private Double score;
+
+  private String comment;
+
+  private LocalDateTime createdAt;
+
+  private LocalDateTime updatedAt;
+
+  public static ReviewResponseDto myReviewList(Review review) {
+
+    return ReviewResponseDto.builder()
+            .beanName(review.getBean().getBeanName())
+            .score(review.getScore())
+            .comment(review.getComment())
+            .createdAt(review.getCreatedAt())
+            .updatedAt(review.getUpdatedAt())
+            .build();
+  }
+
+  public static ReviewResponseDto getBeanReviewList(Review review) {
+
+    return ReviewResponseDto.builder()
+        .memberName(review.getMember().getMemberName())
+        .beanName(review.getBean().getBeanName())
+        .score(review.getScore())
+        .comment(review.getComment())
+        .createdAt(review.getCreatedAt())
+        .updatedAt(review.getUpdatedAt())
+        .build();
+  }
+}

--- a/src/main/java/com/coffee/coffeeserviceproject/review/entity/Review.java
+++ b/src/main/java/com/coffee/coffeeserviceproject/review/entity/Review.java
@@ -1,0 +1,66 @@
+package com.coffee.coffeeserviceproject.review.entity;
+
+import com.coffee.coffeeserviceproject.bean.entity.Bean;
+import com.coffee.coffeeserviceproject.member.entity.Member;
+import com.coffee.coffeeserviceproject.review.dto.ReviewRequestDto;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Review {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne
+  @JoinColumn(name = "member_id", nullable = false)
+  private Member member;
+
+  @ManyToOne
+  @JoinColumn(name = "bean_id", nullable = false)
+  private Bean bean;
+
+  private Double score;
+
+  private String comment;
+
+  private LocalDateTime createdAt;
+
+  private LocalDateTime updatedAt;
+
+  @PrePersist
+  public void onCreate() {
+    this.createdAt = LocalDateTime.now();
+  }
+
+  @PreUpdate
+  public void onUpdate() {
+    this.updatedAt = LocalDateTime.now();
+  }
+
+  public static Review fromDto(Member member, Bean bean, ReviewRequestDto reviewRequestDto) {
+
+    return Review.builder()
+        .member(member)
+        .bean(bean)
+        .score(reviewRequestDto.getScore())
+        .comment(reviewRequestDto.getComment())
+        .build();
+  }
+}

--- a/src/main/java/com/coffee/coffeeserviceproject/review/repository/ReviewRepository.java
+++ b/src/main/java/com/coffee/coffeeserviceproject/review/repository/ReviewRepository.java
@@ -1,0 +1,20 @@
+package com.coffee.coffeeserviceproject.review.repository;
+
+import com.coffee.coffeeserviceproject.review.entity.Review;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+  Page<Review> findAllByMemberId(Long memberId, Pageable pageable);
+
+  Page<Review> findAllByBeanId(Long beanId, Pageable pageable);
+
+  List<Review> findAllByBeanId(Long beanId);
+
+  void deleteAllByBeanId(Long id);
+
+  void deleteAllByMemberId(Long memberId);
+}

--- a/src/main/java/com/coffee/coffeeserviceproject/review/service/ReviewService.java
+++ b/src/main/java/com/coffee/coffeeserviceproject/review/service/ReviewService.java
@@ -1,0 +1,137 @@
+package com.coffee.coffeeserviceproject.review.service;
+
+import static com.coffee.coffeeserviceproject.common.type.ErrorCode.NOT_FOUND_BEAN;
+import static com.coffee.coffeeserviceproject.common.type.ErrorCode.NOT_FOUND_REVIEW;
+import static com.coffee.coffeeserviceproject.common.type.ErrorCode.NOT_PERMISSION;
+import static com.coffee.coffeeserviceproject.common.type.ErrorCode.SCORE_MULTIPLE_05;
+
+import com.coffee.coffeeserviceproject.bean.entity.Bean;
+import com.coffee.coffeeserviceproject.bean.repository.BeanRepository;
+import com.coffee.coffeeserviceproject.common.exception.CustomException;
+import com.coffee.coffeeserviceproject.configuration.JwtProvider;
+import com.coffee.coffeeserviceproject.elasticsearch.document.SearchBeanList;
+import com.coffee.coffeeserviceproject.elasticsearch.repository.SearchRepository;
+import com.coffee.coffeeserviceproject.member.entity.Member;
+import com.coffee.coffeeserviceproject.review.dto.ReviewRequestDto;
+import com.coffee.coffeeserviceproject.review.dto.ReviewResponseDto;
+import com.coffee.coffeeserviceproject.review.entity.Review;
+import com.coffee.coffeeserviceproject.review.repository.ReviewRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewService {
+
+  private final ReviewRepository reviewRepository;
+
+  private final JwtProvider jwtProvider;
+
+  private final BeanRepository beanRepository;
+
+  private final SearchRepository searchRepository;
+
+  @Transactional
+  public void addReview(Long beanId, ReviewRequestDto reviewRequestDto, String token) {
+
+    if (!reviewRequestDto.isValidScore()) {
+      throw new CustomException(SCORE_MULTIPLE_05);
+    }
+
+    Member member = jwtProvider.getMemberFromEmail(token);
+
+    Bean bean = beanRepository.findById(beanId)
+        .orElseThrow(() -> new CustomException(NOT_FOUND_BEAN));
+
+    Review review = Review.fromDto(member, bean, reviewRequestDto);
+
+    reviewRepository.save(review);
+    updateAverageScore(beanId);
+  }
+
+  @Transactional(readOnly = true)
+  public Page<ReviewResponseDto> getMyReviewList(Pageable pageable, String token) {
+
+    Member member = jwtProvider.getMemberFromEmail(token);
+
+    Long memberId = member.getId();
+
+    Page<Review> myReviewPage = reviewRepository.findAllByMemberId(memberId, pageable);
+
+    return myReviewPage.map(ReviewResponseDto::myReviewList);
+  }
+
+  @Transactional(readOnly = true)
+  public Page<ReviewResponseDto> getBeanReviewList(Pageable pageable, Long beanId) {
+
+    Page<Review> getReviewPage = reviewRepository.findAllByBeanId(beanId, pageable);
+
+    return getReviewPage.map(ReviewResponseDto::getBeanReviewList);
+  }
+
+  @Transactional
+  public void updateReview(Long id, String token, String comment) {
+
+    Member member = jwtProvider.getMemberFromEmail(token);
+
+    Review review = reviewRepository.findById(id)
+        .orElseThrow(() -> new CustomException(NOT_FOUND_REVIEW));
+
+    if (!member.getId().equals(review.getMember().getId())) {
+
+      throw new CustomException(NOT_PERMISSION);
+    }
+
+    review.setComment(comment);
+
+    reviewRepository.save(review);
+  }
+
+  @Transactional
+  public void deleteReview(Long id, String token) {
+
+    Member member = jwtProvider.getMemberFromEmail(token);
+
+    Review review = reviewRepository.findById(id)
+        .orElseThrow(() -> new CustomException(NOT_FOUND_REVIEW));
+
+    Long beanId = review.getBean().getId();
+
+    if (!member.getId().equals(review.getMember().getId())) {
+
+      throw new CustomException(NOT_PERMISSION);
+    }
+
+    reviewRepository.delete(review);
+    updateAverageScore(beanId);
+  }
+
+  @Async
+  public void updateAverageScore(Long beanId) {
+
+    List<Review> reviewList = reviewRepository.findAllByBeanId(beanId);
+    if (!reviewList.isEmpty()) {
+      double averageScore = reviewList.stream()
+          .mapToDouble(Review::getScore)
+          .average()
+          .orElse(0.0);
+
+      Bean bean = beanRepository.findById(beanId)
+          .orElseThrow(() -> new CustomException(NOT_FOUND_BEAN));
+
+      bean.setAverageScore(averageScore);
+      beanRepository.save(bean);
+
+      SearchBeanList searchBeanList = searchRepository.findById(beanId)
+          .orElseThrow(() -> new CustomException(NOT_FOUND_BEAN));
+
+      searchBeanList.setAverageScore(averageScore);
+      searchRepository.save(searchBeanList);
+    }
+  }
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,19 @@
+insert into member (email, member_name, password, phone, role, address, created_at,
+                    certification_at)
+values ('sellerTest@test.com', '셀러 테스트',
+        '$2a$10$MbIXWjflj1coLVrazrc1MOim15SCWsbGapr0d2g2YLFGF6OgjnJMy', '010-1234-5678', 'SELLER',
+        'testAddress', '2024-10-22 15:14:46', '2024-10-22 15:14:46'),
+       ('buyerTest@test.com', '바이어 테스트',
+        '$2a$10$MbIXWjflj1coLVrazrc1MOim15SCWsbGapr0d2g2YLFGF6OgjnJMh', '010-2345-6789', 'BUYER',
+        'testAddress', '2024-10-22 15:14:46', '2024-10-22 15:14:46');
+
+insert into roaster (member_id, roaster_name, office_address, contact_info, description, created_at)
+values ('1', '로스터명', '주소', '010-5555-6666', '설명', '2024-10-22 15:14:46');
+
+insert into bean (member_id, bean_name, bean_state, bean_region, bean_farm, bean_variety, altitude,
+                  process, grade,
+                  roasting_level, roasting_date, cup_note, espresso_recipe, filter_recipe,
+                  milk_pairing,
+                  signature_variation, price, purchase_status)
+values (1, '이름', '국가', '지역', '농장', '품종', '고도', '가공법', '등급', '미디움', '어제', '굿', '에쏘 레싶', '필터 레싶',
+        '추천우유', '시그니처', 10, 'POSSIBLE');

--- a/src/test/java/com/coffee/coffeeserviceproject/favorite/service/FavoriteServiceTest.java
+++ b/src/test/java/com/coffee/coffeeserviceproject/favorite/service/FavoriteServiceTest.java
@@ -1,0 +1,132 @@
+package com.coffee.coffeeserviceproject.favorite.service;
+
+import static com.coffee.coffeeserviceproject.common.type.ErrorCode.ALREADY_FAVORITE_BEAN;
+import static com.coffee.coffeeserviceproject.common.type.ErrorCode.NOT_FOUND_BEAN;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.coffee.coffeeserviceproject.bean.entity.Bean;
+import com.coffee.coffeeserviceproject.bean.repository.BeanRepository;
+import com.coffee.coffeeserviceproject.common.exception.CustomException;
+import com.coffee.coffeeserviceproject.configuration.JwtProvider;
+import com.coffee.coffeeserviceproject.favorite.dto.FavoriteDto;
+import com.coffee.coffeeserviceproject.favorite.entity.Favorite;
+import com.coffee.coffeeserviceproject.favorite.repository.FavoriteRepository;
+import com.coffee.coffeeserviceproject.member.entity.Member;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+@ExtendWith(MockitoExtension.class)
+class FavoriteServiceTest {
+
+  @Mock
+  private FavoriteRepository favoriteRepository;
+
+  @Mock
+  private JwtProvider jwtProvider;
+
+  @Mock
+  private BeanRepository beanRepository;
+
+  @InjectMocks
+  private FavoriteService favoriteService;
+
+  private Member member;
+  private Bean bean;
+  private Favorite favorite;
+  private String token;
+
+  @BeforeEach
+  void setUp() {
+
+    token = "token";
+
+    member = new Member();
+    member.setId(1L);
+
+    bean = new Bean();
+    bean.setId(1L);
+
+    favorite = new Favorite();
+    favorite.setMember(member);
+    favorite.setBean(bean);
+  }
+
+  @Test
+  void addFavorite_Success() {
+    // given
+    when(jwtProvider.getMemberFromEmail(token)).thenReturn(member);
+    when(beanRepository.findById(bean.getId())).thenReturn(Optional.of(bean));
+    // when
+    favoriteService.addFavorite(bean.getId(), token);
+    // then
+    verify(favoriteRepository).save(favorite);
+  }
+
+  @Test
+  void addFavorite_Failure_AlreadyFavoriteBean() {
+    // given
+    Favorite existsFavorite = Favorite.builder()
+        .id(2L)
+        .member(member)
+        .bean(bean)
+        .build();
+
+    when(jwtProvider.getMemberFromEmail(token)).thenReturn(member);
+    when(beanRepository.findById(bean.getId())).thenReturn(Optional.of(bean));
+    when(favoriteRepository.findByMemberAndBean(member, bean)).thenReturn(Optional.of(existsFavorite));
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> favoriteService.addFavorite(bean.getId(), token));
+    // then
+    assertEquals(ALREADY_FAVORITE_BEAN, e.getErrorCode());
+    verify(favoriteRepository, never()).save(favorite);
+  }
+
+  @Test
+  void addFavorite_Failure_NotFoundBean() {
+    // given
+    when(jwtProvider.getMemberFromEmail(token)).thenReturn(member);
+    when(beanRepository.findById(bean.getId())).thenReturn(Optional.empty());
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> favoriteService.addFavorite(bean.getId(), token));
+    // then
+    assertEquals(NOT_FOUND_BEAN, e.getErrorCode());
+    verify(favoriteRepository, never()).save(favorite);
+  }
+
+  @Test
+  void getFavorites_Success() {
+    // given
+    Pageable pageable = Pageable.ofSize(10);
+
+    Favorite favorite2 = Favorite.builder()
+        .id(2L)
+        .member(member)
+        .bean(bean)
+        .build();
+
+    Page<Favorite> getFavoritePage = new PageImpl<>(List.of(favorite, favorite2));
+    when(jwtProvider.getMemberFromEmail(token)).thenReturn(member);
+    when(favoriteRepository.findAllByMemberId(member.getId(), pageable)).thenReturn(getFavoritePage);
+    // when
+    Page<FavoriteDto> favoritePage = favoriteService.getFavoriteList(token, pageable);
+    // then
+    assertNotNull(favoritePage);
+    assertEquals(2, favoritePage.getTotalElements());
+  }
+}

--- a/src/test/java/com/coffee/coffeeserviceproject/member/service/MemberServiceTest.java
+++ b/src/test/java/com/coffee/coffeeserviceproject/member/service/MemberServiceTest.java
@@ -18,13 +18,15 @@ import static org.mockito.Mockito.when;
 
 import com.coffee.coffeeserviceproject.bean.repository.BeanRepository;
 import com.coffee.coffeeserviceproject.common.exception.CustomException;
+import com.coffee.coffeeserviceproject.configuration.JwtProvider;
+import com.coffee.coffeeserviceproject.favorite.repository.FavoriteRepository;
 import com.coffee.coffeeserviceproject.member.dto.MemberDeleteDto;
 import com.coffee.coffeeserviceproject.member.dto.MemberDto;
 import com.coffee.coffeeserviceproject.member.dto.MemberUpdateDto;
 import com.coffee.coffeeserviceproject.member.entity.Member;
 import com.coffee.coffeeserviceproject.member.entity.Roaster;
 import com.coffee.coffeeserviceproject.member.repository.MemberRepository;
-import com.coffee.coffeeserviceproject.configuration.JwtProvider;
+import com.coffee.coffeeserviceproject.review.repository.ReviewRepository;
 import com.coffee.coffeeserviceproject.util.PasswordUtil;
 import java.util.Collections;
 import java.util.Optional;
@@ -52,6 +54,12 @@ class MemberServiceTest {
 
   @Mock
   private JwtProvider jwtProvider;
+
+  @Mock
+  private ReviewRepository reviewRepository;
+
+  @Mock
+  private FavoriteRepository favoriteRepository;
 
   private Member member;
   private MemberDto memberDto;
@@ -255,7 +263,9 @@ class MemberServiceTest {
     // when
     memberService.deleteMember("token", deleteDto);
     // then
-    verify(memberRepository).delete(any());
+    verify(memberRepository).deleteById(memberId);
+    verify(reviewRepository).deleteAllByMemberId(memberId);
+    verify(favoriteRepository).deleteAllByMemberId(memberId);
   }
 
   @Test
@@ -271,5 +281,7 @@ class MemberServiceTest {
         () -> memberService.deleteMember("token", memberDeleteDto));
     // then
     assertEquals(WRONG_PASSWORD, e.getErrorCode());
+    verify(memberRepository, never()).delete(any());
+    verify(reviewRepository, never()).deleteAllByMemberId(member.getId());
   }
 }

--- a/src/test/java/com/coffee/coffeeserviceproject/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/coffee/coffeeserviceproject/review/service/ReviewServiceTest.java
@@ -1,0 +1,395 @@
+package com.coffee.coffeeserviceproject.review.service;
+
+import static com.coffee.coffeeserviceproject.common.type.ErrorCode.NOT_FOUND_REVIEW;
+import static com.coffee.coffeeserviceproject.common.type.ErrorCode.NOT_PERMISSION;
+import static com.coffee.coffeeserviceproject.common.type.ErrorCode.SCORE_MULTIPLE_05;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.coffee.coffeeserviceproject.bean.entity.Bean;
+import com.coffee.coffeeserviceproject.bean.repository.BeanRepository;
+import com.coffee.coffeeserviceproject.common.exception.CustomException;
+import com.coffee.coffeeserviceproject.configuration.JwtProvider;
+import com.coffee.coffeeserviceproject.elasticsearch.document.SearchBeanList;
+import com.coffee.coffeeserviceproject.elasticsearch.repository.SearchRepository;
+import com.coffee.coffeeserviceproject.member.entity.Member;
+import com.coffee.coffeeserviceproject.review.dto.ReviewRequestDto;
+import com.coffee.coffeeserviceproject.review.dto.ReviewResponseDto;
+import com.coffee.coffeeserviceproject.review.entity.Review;
+import com.coffee.coffeeserviceproject.review.repository.ReviewRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+@ExtendWith(MockitoExtension.class)
+class ReviewServiceTest {
+
+  @Mock
+  private ReviewRepository reviewRepository;
+
+  @Mock
+  private JwtProvider jwtProvider;
+
+  @Mock
+  private BeanRepository beanRepository;
+
+  @Mock
+  private SearchRepository searchRepository;
+
+  @InjectMocks
+  private ReviewService reviewService;
+
+  private Member member;
+  private Bean bean;
+  private ReviewRequestDto reviewRequestDto;
+
+  private String token;
+
+  @BeforeEach
+  void setUp() {
+
+    token = "token";
+
+    member = new Member();
+    member.setId(1L);
+
+    bean = new Bean();
+    bean.setId(1L);
+    bean.setAverageScore(0.0);
+
+    reviewRequestDto = new ReviewRequestDto();
+    reviewRequestDto.setScore(5.0);
+    reviewRequestDto.setComment("굿");
+  }
+
+  @Test
+  void addReview_Success() {
+    // given
+    when(jwtProvider.getMemberFromEmail(token)).thenReturn(member);
+    when(beanRepository.findById(bean.getId())).thenReturn(Optional.of(bean));
+
+    // when
+    reviewService.addReview(bean.getId(), reviewRequestDto, token);
+    // then
+    ArgumentCaptor<Review> captor = ArgumentCaptor.forClass(Review.class);
+    verify(reviewRepository).save(captor.capture());
+
+    Review review = captor.getValue();
+    assertEquals("굿", review.getComment());
+    assertEquals(5.0, review.getScore());
+  }
+
+  @Test
+  void addReview_Success_AverageScore() {
+    // given
+    Review review = Review.builder()
+        .score(5.0)
+        .bean(bean)
+        .build();
+
+    Review newReview = new Review();
+    newReview.setBean(bean);
+    newReview.setScore(3.0);
+
+    when(reviewRepository.findAllByBeanId(bean.getId())).thenReturn(List.of(review, newReview));
+    when(beanRepository.findById(bean.getId())).thenReturn(Optional.of(bean));
+    when(searchRepository.findById(bean.getId())).thenReturn(
+        Optional.of(SearchBeanList.builder().build()));
+    // when
+    reviewService.updateAverageScore(bean.getId());
+
+    // then
+    ArgumentCaptor<Bean> captor = ArgumentCaptor.forClass(Bean.class);
+
+    verify(beanRepository).save(captor.capture());
+    assertEquals(4.0, captor.getValue().getAverageScore());
+
+    ArgumentCaptor<SearchBeanList> searchCaptor = ArgumentCaptor.forClass(SearchBeanList.class);
+
+    verify(searchRepository).save(searchCaptor.capture());
+    assertEquals(4.0, searchCaptor.getValue().getAverageScore());
+  }
+
+  @Test
+  void addReview_Failure_SCORE_MULTIPLE_05() {
+    // given
+    reviewRequestDto.setScore(4.3);
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> reviewService.addReview(bean.getId(), reviewRequestDto, token));
+    // then
+    verify(reviewRepository, never()).save(any());
+    assertEquals(SCORE_MULTIPLE_05, e.getErrorCode());
+  }
+
+  @Test
+  void getMyReview_Success() {
+    // given
+    Pageable pageable = Pageable.ofSize(10);
+
+    Bean bean2 = new Bean();
+    bean2.setId(2L);
+
+    Bean bean3 = new Bean();
+    bean3.setId(3L);
+
+    Review review1 = Review.builder()
+        .score(5.0)
+        .member(member)
+        .bean(bean)
+        .build();
+
+    Review review2 = Review.builder()
+        .score(5.0)
+        .member(member)
+        .bean(bean2)
+        .build();
+
+    Review review3 = Review.builder()
+        .score(5.0)
+        .member(member)
+        .bean(bean3)
+        .build();
+
+    Page<Review> getReviewPage = new PageImpl<>(List.of(review1, review2, review3));
+
+    when(jwtProvider.getMemberFromEmail(token)).thenReturn(member);
+    when(reviewRepository.findAllByMemberId(member.getId(), pageable)).thenReturn(getReviewPage);
+    // when
+    Page<ReviewResponseDto> myReviews = reviewService.getMyReviewList(pageable, token);
+    // then
+    assertNotNull(myReviews);
+    assertEquals(3, myReviews.getTotalElements());
+  }
+
+  @Test
+  void getMyReview_Success_EmptyList() {
+    // given
+    Pageable pageable = Pageable.ofSize(10);
+
+    Page<Review> getReviewPage = new PageImpl<>(List.of());
+
+    when(jwtProvider.getMemberFromEmail(token)).thenReturn(member);
+    when(reviewRepository.findAllByMemberId(member.getId(), pageable)).thenReturn(getReviewPage);
+    // when
+    Page<ReviewResponseDto> myReviews = reviewService.getMyReviewList(pageable, token);
+    // then
+    assertNotNull(myReviews);
+    assertTrue(myReviews.getContent().isEmpty());
+  }
+
+  @Test
+  void getBeanReviewList_Success() {
+    // given
+    Pageable pageable = Pageable.ofSize(10);
+
+    Member member2 = new Member();
+    member2.setId(2L);
+
+    Review review1 = Review.builder()
+        .score(5.0)
+        .member(member)
+        .bean(bean)
+        .build();
+
+    Review review2 = Review.builder()
+        .score(5.0)
+        .member(member)
+        .bean(bean)
+        .build();
+
+    Review review3 = Review.builder()
+        .score(5.0)
+        .member(member2)
+        .bean(bean)
+        .build();
+
+    Page<Review> getReviewPage = new PageImpl<>(List.of(review1, review2, review3));
+    when(reviewRepository.findAllByBeanId(bean.getId(), pageable)).thenReturn(getReviewPage);
+    // when
+    Page<ReviewResponseDto> beanReviews = reviewService.getBeanReviewList(pageable, bean.getId());
+    // then
+    assertNotNull(beanReviews);
+    assertEquals(3, beanReviews.getTotalElements());
+  }
+
+  @Test
+  void getBeanReviewList_Success_EmptyList() {
+    // given
+    Pageable pageable = Pageable.ofSize(10);
+
+    Page<Review> getReviewPage = new PageImpl<>(List.of());
+    when(reviewRepository.findAllByBeanId(bean.getId(), pageable)).thenReturn(getReviewPage);
+    // when
+    Page<ReviewResponseDto> beanReviews = reviewService.getBeanReviewList(pageable, bean.getId());
+    // then
+    assertNotNull(beanReviews);
+    assertTrue(beanReviews.getContent().isEmpty());
+  }
+
+  @Test
+  void updateReview_Success() {
+    // given
+    Review review = Review.builder()
+        .id(1L)
+        .score(5.0)
+        .member(member)
+        .bean(bean)
+        .comment("굿")
+        .build();
+
+    when(jwtProvider.getMemberFromEmail(token)).thenReturn(member);
+    when(reviewRepository.findById(review.getId())).thenReturn(Optional.of(review));
+    // when
+    reviewService.updateReview(review.getId(), token, "베리 굿");
+    // then
+    verify(reviewRepository).save(any(Review.class));
+    assertEquals("베리 굿", review.getComment());
+  }
+
+  @Test
+  void updateReview_Failure_NotFoundReview() {
+    // given
+    when(jwtProvider.getMemberFromEmail(token)).thenReturn(member);
+    when(reviewRepository.findById(any())).thenReturn(Optional.empty());
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> reviewService.updateReview(any(), token, "베리 굿"));
+    // then
+    verify(reviewRepository, never()).save(any(Review.class));
+    assertEquals(NOT_FOUND_REVIEW, e.getErrorCode());
+  }
+
+  @Test
+  void updateReview_Failure_NotPermission() {
+    // given
+    Member member2 = new Member();
+    member2.setId(2L);
+
+    Review review = Review.builder()
+        .id(1L)
+        .score(5.0)
+        .member(member)
+        .bean(bean)
+        .comment("굿")
+        .build();
+
+    when(jwtProvider.getMemberFromEmail(token)).thenReturn(member2);
+    when(reviewRepository.findById(review.getId())).thenReturn(Optional.of(review));
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> reviewService.updateReview(review.getId(), token, "베리 굿"));
+    // then
+    verify(reviewRepository, never()).save(any(Review.class));
+    assertEquals(NOT_PERMISSION, e.getErrorCode());
+  }
+
+  @Test
+  void deleteReview_Success() {
+    // given
+    Review review = Review.builder()
+        .id(1L)
+        .score(5.0)
+        .member(member)
+        .bean(bean)
+        .build();
+
+    when(jwtProvider.getMemberFromEmail(token)).thenReturn(member);
+    when(reviewRepository.findById(review.getId())).thenReturn(Optional.of(review));
+    // when
+    reviewService.deleteReview(review.getId(), token);
+    // then
+    verify(reviewRepository).delete(any(Review.class));
+  }
+
+  @Test
+  void deleteReview_Success_AverageScore() {
+    // given
+    Member member2 = new Member();
+    member2.setId(2L);
+
+    Review review = Review.builder()
+        .id(1L)
+        .score(5.0)
+        .member(member)
+        .bean(bean)
+        .build();
+
+    Review review2 = Review.builder()
+        .id(2L)
+        .score(3.0)
+        .member(member2)
+        .bean(bean)
+        .build();
+
+    when(reviewRepository.findAllByBeanId(bean.getId())).thenReturn(List.of(review, review2));
+    when(beanRepository.findById(bean.getId())).thenReturn(Optional.of(bean));
+    when(searchRepository.findById(bean.getId())).thenReturn(
+        Optional.of(SearchBeanList.builder().build()));
+    // when
+    when(reviewRepository.findAllByBeanId(bean.getId())).thenReturn(List.of(review2));
+    reviewService.updateAverageScore(bean.getId());
+
+    // then
+    ArgumentCaptor<Bean> captor = ArgumentCaptor.forClass(Bean.class);
+
+    verify(beanRepository).save(captor.capture());
+    assertEquals(3.0, captor.getValue().getAverageScore());
+
+    ArgumentCaptor<SearchBeanList> searchCaptor = ArgumentCaptor.forClass(SearchBeanList.class);
+
+    verify(searchRepository).save(searchCaptor.capture());
+    assertEquals(3.0, searchCaptor.getValue().getAverageScore());
+  }
+
+  @Test
+  void deleteReview_Failure_NotFoundReview() {
+    // given
+    when(jwtProvider.getMemberFromEmail(token)).thenReturn(member);
+    when(reviewRepository.findById(1L)).thenReturn(Optional.empty());
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> reviewService.deleteReview(1L, token));
+    // then
+    verify(reviewRepository, never()).delete(any(Review.class));
+    assertEquals(NOT_FOUND_REVIEW, e.getErrorCode());
+  }
+
+  @Test
+  void deleteReview_Failure_NotPermission() {
+    // given
+    Member member2 = new Member();
+    member2.setId(2L);
+
+    Review review = Review.builder()
+        .id(1L)
+        .score(5.0)
+        .member(member)
+        .bean(bean)
+        .build();
+
+    when(jwtProvider.getMemberFromEmail(token)).thenReturn(member2);
+    when(reviewRepository.findById(review.getId())).thenReturn(Optional.of(review));
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> reviewService.deleteReview(review.getId(), token));
+    // then
+    verify(reviewRepository, never()).delete(any(Review.class));
+    assertEquals(NOT_PERMISSION, e.getErrorCode());
+  }
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

- 이전 작업으로 회원관련 로직, 원두 레시피 등록 및 레시피 조회 로직, 장바구니 관련 로직, 결제 관련 로직 구현 완료
- 등록된 원두 레시피에서 리뷰 관련 로직 구현하기
- 즐겨찾기 관련 로직 구현하기

**TO-BE**

[공통]
- Review 테이블은 Member 테이블과 1 : N 관계로 설정
- Review 테이블은 Bean 테이블과 1 : N 관계로 설정
- 리뷰를 작성한 회원이 탈퇴한 경우 작성한 모든 리뷰를 삭제하고, 평균 별점 업데이트
- 특정 원두 에 리뷰가 작성되어있을 때, 해당 원두를 삭제하는 경우, 해당 원두에 등록이 된 모든 리뷰를 삭제하고, 평균 별점 업데이트
- 원두 삭제를 할 경우 해당 원두랑 연결되어있는 검색기능, 즐겨찾기기능, 리뷰기능 들도 같이 삭제를 해줘야 하므로, 비동기 작업으로 나누어 삭제 진행
- 회원 탈퇴를 할 경우 여러개의 원두등록, 여러개의 즐겨찾기, 여러개의 리뷰 등이 있을 수 있으며, 이럴 경우 비동기 작업으로 나누어 삭제를 진행하고, 많은 데이터가 있을 수 있으니 한번에 처리하는 데이터 양을 제한하여 서버의 과부하를 방지하고, 여러번에 나누어 성능을 최적화 함. 그리고 각 삭제 작업이 순차적으로 진행됨으로써 동시성 문제를 최소화 할 수 있게 작업

[리뷰 등록]
- token 을 활용하여 회원을 조회하고, 별점과 코멘트를 남길 수 있음
- score 최소 점수는 0.0, 최고 점수는 5.0 으로 설정
- 0.5 단위로 점수를 줄 수 있으며, 아닐 시 예외 처리
- 리뷰 등록 시 특정 원두의 평균 별점을 계산한 후 Bean 테이블의 average_score Column 에 등록
- 계산된 평균 별점은 Elasticsearch 에도 반영

[리뷰 조회 - 회원]
- token 을 활용하여 회원을 조회하고, 그 회원이 작성한 리뷰 조회
- 조회된 리뷰는 Paging 처리

[리뷰 조회 - 원두]
- 특정 원두에 등록된 리뷰를 조회할 수 있는 로직 구현
- 조회된 리뷰는 Paging 처리
- 회원이 아니더라도 리뷰 조회 가능

[리뷰 수정]
- 한 번 등록한 리뷰 별점은 수정이 불가능 하지만, 코멘트는 수정 가능
- 리뷰를 등록한 본인만 수정이 가능

[리뷰 삭제]
- token 을 활용하여 회원을 조회하고, 그 회원이 작성한 리뷰 삭제
- 리뷰 삭제 시 해당 원두의 별점을 계산한 후 Bean 테이블의 average_socre Column 에 등록
- 계산된 평균 별점은 Elasticsearch 에도 반영

[즐겨찾기 추가]
- token 을 활용하여 회원을 조회하고, 해당 원두를 즐겨찾기에 추가

[즐겨찾기 조회]
- token 을 활용하여 회원을 조회하고, 해당 ID 값으로 Favorite 테이블에서 조회

[즐겨찾기 삭제]
- token 을 활용하여 회원을 조회하고, 해당 ID 값으로 Favorite 테이블에서 즐겨찾기 삭제
- 즐겨찾기를 추가한 사용자만 즐겨찾기 삭제 가능

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드

[리뷰 등록 테스트]
- 사용자가 존재하는 원두에 리뷰를 등록할 시 정상적으로 리뷰가 등록이 되는지 확인
- 이미 존재하는 원두에 리뷰가 있을 시, 새로운 리뷰를 등록하면 평균 별점으로 계산이 되는지 확인
- 별점이 정상적이지 않은 입력이 주어졌을 때(0.5 단위가 아닌) 예외가 발생하는 지 검증

[리뷰 조회 테스트 - 회원]
- 한 사용자가 여러 원두에 리뷰를 등록한 경우 그 사용자가 등록한 리뷰가 정상적으로 조회가 되는지 확인
- 해당 사용자가 등록한 리뷰가 없으면 빈 배열을 반환하는 지 확인

[리뷰 조회 테스트 - 원두]
- 특정 원두에 여러 사용자가 리뷰를 등록한 경우 그 원두에 등록된 리뷰가 정상적으로 조회가 되는지 확인
- 해당 원두에 등록된 리뷰가 없으면 빈 배열을 반환하는 지 확인

[리뷰 수정 테스트]
- 이미 등록된 리뷰 코멘트를 정상적으로 수정이 되는지 확인
- 리뷰가 없는 경우 예외가 발생하는 지 검증
- 본인이 등록한 리뷰가 아닌경우 수정을 시도할 시 예외가 발생하는 지 검증

[리뷰 삭제 테스트]
- 리뷰가 정상적으로 삭제가 되는지 확인
- 해당 원두에 복수의 리뷰가 등록된 경우 해당 리뷰를 삭제할 시 평균 별점으로 계산이 되는지 확인
- 리뷰가 없는 경우 예외가 발생하는 지 검증
- 본인이 등록한 리뷰가 아닌경우 삭제를 시도할 시 예외가 발생하는 지 검증

[즐겨찾기 추가 테스트]
- 즐겨찾기에 정상적으로 추가가 되는지 확인
- 이미 즐겨찾기를 한 원두인 경우 예외처리가 발생하는 지 검증
- 즐겨찾기 할 원두를 찾지 못 한 경우 예외처리가 발생하는 지 검증

[즐겨찾기 조회]
- 등록한 즐겨찾기가 반환이 되는지 확인
- 등록된 즐겨찾기가 없는 경우 빈 배열을 반환하는지 확인

[즐겨찾기 삭제]
- 등록된 즐겨찾기를 성공적으로 삭제하는지 확인
- 등록된 즐겨찾기가 없는 경우 삭제 시도 시 예외가 발생하는 지 검증
- 본인이 등록한 즐겨찾기가 아닌 경우 삭제 시도 시 예외가 발생하는 지 검증

[테스트코드 추가]
- 회원 탈퇴할 시 작성한 리뷰가 모두 삭제되는 지 확인
- 등록한 원두를 삭제할 시 작성된 리뷰가 모두 삭제되는 지 확인

- [ ] API 테스트

- 한 사용자가 리뷰와 원두 등 등록한적이 있을 때 연관되어있는 엔티티 컬럼도 같이 삭제가 되는지 확인
- 각 상황에 맞게 예외처리된 문구와 성공 케이스들 확인 완료